### PR TITLE
fix(cloudmos-to-akash-console): updated docs to reference akash console instead of cloud deploy

### DIFF
--- a/src/content/Docs/deployments/akash-console/index.md
+++ b/src/content/Docs/deployments/akash-console/index.md
@@ -1,16 +1,16 @@
 ---
-categories: ["Cloudmos Deploy"]
+categories: ["Akash Console"]
 tags: ["CLI"]
-weight: 5
-title: "Cloudmos Deploy"
-linkTitle: Cloudmos Deploy
+weight: 2
+title: "Akash Console"
+linkTitle: Akash Console
 ---
 
-Cloudmos Deploy Tool is a web based application which simplifies the deployment process on the Akash Network. Post deployment the tool provides a dashboard to view the status and details of workloads. The dashboard also has the ability to perform administrative tasks including closing the deployment, updating the deployment, redeploying, and increasing the funding available to the deployment.
+Akash Console Tool is a web based application which simplifies the deployment process on the Akash Network. Post deployment the tool provides a dashboard to view the status and details of workloads. The dashboard also has the ability to perform administrative tasks including closing the deployment, updating the deployment, redeploying, and increasing the funding available to the deployment.
 
 This guide will cover the following topics:
 
-- [Cloudmos Deploy Access](#cloudmos-deploy-access)
+- [Akash Console Access](#cloudmos-deploy-access)
 - [Minecraft Deployment Example](#minecraft-deployment-example)
 - [Manage Deployments](#manage-deployments)
 - [Define a custom RPC node](#custom-rpc-node)
@@ -25,7 +25,7 @@ Once you share your app, someone from the Akash team may reach out to spotlight 
 
 This is a great opportunity to connect with the team at Akash Network and to spotlight your work for our world-class community.
 
-## Cloudmos Deploy Access
+## Akash Console Access
 
 ### **Before Getting Started**
 
@@ -33,11 +33,11 @@ The Keplr and Leap browser extensions must be installed and with sufficient fund
 
 Follow our [Keplr Wallet](/docs/getting-started/token-and-wallets/#keplr-wallet) and [Leap Cosmos Wallet](/docs/getting-started/token-and-wallets/#leap-cosmos-wallet) guides to create your first wallet if necessary.
 
-### **Cloudmos Deploy Access**
+### **Akash Console Access**
 
-The Cloudmos Deploy web app is available via the following URL:
+The Akash Console web app is available via the following URL:
 
-- [https://deploy.cloudmos.io/](https://deploy.cloudmos.io/)
+- [https://console.akash.network/](https://console.akash.network/)
 
 ## Keplr Account Selection
 
@@ -53,7 +53,7 @@ Ensure that an Akash account with sufficient AKT balance is selected in Leap pri
 
 ## Minecraft Deployment Example
 
-In this section we will use Cloudmos Deploy to launch an example Minecraft deployment on the Akash Network. You can follow the same process for any other workload so long as it is containerized and you have an appropriate SDL.
+In this section we will use Akash Console to launch an example Minecraft deployment on the Akash Network. You can follow the same process for any other workload so long as it is containerized and you have an appropriate SDL.
 
 #### **STEP 1 - Create the Deployment**
 
@@ -64,7 +64,7 @@ In this section we will use Cloudmos Deploy to launch an example Minecraft deplo
 #### **STEP 2 - Create Certficate**
 
 - A number of checks are performed to ensure necessary funds and certificates are available to launch a deployment.
-- If this is your first deployment with Cloudmos Deploy a `CREATE CERTIFICATE` prompt will be displayed. Select the `CREATE CERTIFICATE` button and accept transaction fee prompt from Keplr to proceed.
+- If this is your first deployment with Akash Console a `CREATE CERTIFICATE` prompt will be displayed. Select the `CREATE CERTIFICATE` button and accept transaction fee prompt from Keplr to proceed.
 
 ![](../../assets/cloudmosCreateCert.png)
 
@@ -109,7 +109,7 @@ In this section we will use Cloudmos Deploy to launch an example Minecraft deplo
 
 ## Manage Deployments
 
-There are a several important management operations you can do with the Cloudmos Deploy tool including:
+There are a several important management operations you can do with the Akash Console tool including:
 
 - [Add funds to existing deployment’s Escrow Account](#add-funding-to-active-deployment)
 - [Close an active deployment](#close-active-deployment)
@@ -151,9 +151,9 @@ Closing a deployment is very simple.
 
 # Custom RPC Node
 
-Specify a custom RPC or API node within Cloudmos Deploy by using the steps outlined in this section.&#x20;
+Specify a custom RPC or API node within Akash Console by using the steps outlined in this section.&#x20;
 
-The custom node option can point to a RPC node we have created and manage ourselves. Or we can point to an alternative public RPC node that was not selected by Cloudmos Deploy auto selection.
+The custom node option can point to a RPC node we have created and manage ourselves. Or we can point to an alternative public RPC node that was not selected by Akash Console auto selection.
 
 ### STEP 1 - Enable Custom Node Use
 

--- a/src/content/Docs/deployments/apps-on-akash/index.md
+++ b/src/content/Docs/deployments/apps-on-akash/index.md
@@ -1,7 +1,7 @@
 ---
 categories: ["Apps on Akash"]
 tags: ["CLI"]
-weight: 5
+weight: 7
 title: "Apps on Akash"
 linkTitle: Apps on Akash
 ---
@@ -10,7 +10,7 @@ Awesome Akash is a curated list of awesome resources people can use to familiari
 
 **Repository**: [akash-network/awesome-akash](https://github.com/akash-network/awesome-akash)
 
-**Instructions:** [how to deploy](/docs/deployments/cloudmos-deploy/) the SDL files in this repository
+**Instructions:** [how to deploy](/docs/deployments/akash-console/) the SDL files in this repository
 
 Join our [discord](https://discord.akash.network) if you have questions or concerns. Our team is always eager to hear from you. Also, follow [@akashnet\_](https://twitter.com/akashnet_) to stay in the loop with updates and announcements.
 

--- a/src/content/Docs/deployments/overview/index.md
+++ b/src/content/Docs/deployments/overview/index.md
@@ -3,12 +3,12 @@ categories: ["Deployment"]
 tags: []
 title: "Deployment Overview"
 linkTitle: "Deployment Overview"
-weight: 3
+weight: 1
 ---
 
 Applications can be deployed onto the Akash network using a platform that best suits your needs and preferences. Explore the following guides for your unique use case.
 
-- [Cloudmos Deploy (web app)](/docs/deployments/cloudmos-deploy/)
+- [Akash Console](/docs/deployments/akash-console/)
 - [Using the Command Line for Akash Deployments ](/docs/deployments/akash-cli/installation/)
 - [Akash Sandbox Use](/docs/deployments/sandbox/introduction/)
 - [Awesome Akash Example Distributed Applications](/docs/deployments/apps-on-akash/)

--- a/src/content/Docs/deployments/sandbox/introduction/index.md
+++ b/src/content/Docs/deployments/sandbox/introduction/index.md
@@ -1,7 +1,7 @@
 ---
 categories: ["Introduction"]
 tags: ["CLI"]
-weight: 5
+weight: 4
 title: "SandBox Introduction"
 linkTitle: SandBox Introduction
 ---
@@ -14,6 +14,6 @@ The Akash Sandbox version matches the current Mainnet version.
 
 Use the following documentation for sandbox use and depending on your preferred deployment tool.
 
-> _**NOTE**_ - this documentation covers the use of the Akash CLI for deployment creation and management. The [Cloudmos Deploy](/docs/deployments/cloudmos-deploy/) also now support Sandbox network use. Simply update the network in Settings from `Mainnet` to `Sandbox` to deploy using these web apps.
+> _**NOTE**_ - this documentation covers the use of the Akash CLI for deployment creation and management. The [Cloudmos Deploy](/docs/deployments/akash-console/) also now support Sandbox network use. Simply update the network in Settings from `Mainnet` to `Sandbox` to deploy using these web apps.
 
 - [Akash CLI for Sandbox Use](/docs/deployments/sandbox/installation/)

--- a/src/content/Docs/getting-started/intro-to-akash/akash-network/index.md
+++ b/src/content/Docs/getting-started/intro-to-akash/akash-network/index.md
@@ -35,7 +35,7 @@ The cost of hosting your application using Akash is about one-third the cost of 
 
 ### How do I use Akash?
 
-If you're new to Akash, start with our [**deployment guides**](/docs/deployments/cloudmos-deploy/) and go from there. Akash's community has written several more advanced guides for learning about Akash: a [**node operator guide**](/docs/akash-nodes/akash-node-via-helm-chart/), a [**validator guide**](validating/validator.md), a [**cloud provider guide**](broken-reference), and several [**deployment guides**](/docs/deployments/cloudmos-deploy/) for running various apps on Akash.
+If you're new to Akash, start with our [**deployment guides**](/docs/deployments/akash-console/) and go from there. Akash's community has written several more advanced guides for learning about Akash: a [**node operator guide**](/docs/akash-nodes/akash-node-via-helm-chart/), a [**validator guide**](validating/validator.md), a [**cloud provider guide**](broken-reference), and several [**deployment guides**](/docs/deployments/akash-console/) for running various apps on Akash.
 
 ### Why is Akash different than other Cloud platforms?
 

--- a/src/content/Docs/guides/helium-validator/index.md
+++ b/src/content/Docs/guides/helium-validator/index.md
@@ -34,7 +34,7 @@ You can deploy the validator on Akash using the example deploy.yml. Note that to
 
 Either clone this repository or create a `deploy.yml` file. Enter your S3 bucket and IAM credentials into the `env` section. If you have a swarm_key already, make sure this is uploaded to S3 in the same location as S3_KEY_PATH.
 
-Deploy as [per the docs](/docs/deployments/cloudmos-deploy/) or using a [deploy UI](https://github.com/tombeynon/akash-deploy).
+Deploy as [per the docs](/docs/deployments/akash-console/) or using a [deploy UI](https://github.com/tombeynon/akash-deploy).
 
 Once the container is deployed, check the logs to see your address once the server starts (can take a while). If your swarm_key didn't exist in S3 before, the new one should have been uploaded. Subsequent deploys using the same S3 details will now use the same swarm_key.
 

--- a/src/content/Docs/guides/mine-raptoreum-on-akash/index.md
+++ b/src/content/Docs/guides/mine-raptoreum-on-akash/index.md
@@ -19,7 +19,7 @@ Welcome [**Raptoreum**](https://raptoreum.com) \*\*\*\* miners! [**Akash**](http
 2. Install [**Cloudmos Deploy**](https://cloudmos.io/cloud-deploy) \*\*\*\* and import your AKT wallet address from Keplr
 3. [**Fund your wallet**](https://github.com/akash-network/awesome-akash/blob/raptoreum/raptoreum-miner/README.md#Quickest-way-to-get-more-AKT)
 
-For additional help we recommend you [**follow our full deployment guide**](/docs/deployments/cloudmos-deploy/) \*\*\*\* in parallel with this guide.
+For additional help we recommend you [**follow our full deployment guide**](/docs/deployments/akash-console/) \*\*\*\* in parallel with this guide.
 
 ## How does this work?
 

--- a/src/content/Docs/guides/polygon-on-akash/index.md
+++ b/src/content/Docs/guides/polygon-on-akash/index.md
@@ -30,7 +30,7 @@ If you want a deeper understanding of Polygon and Akash, see these architecture 
 
 ## Akash Application Tools
 
-This [_**guide**_](/docs/deployments/cloudmos-deploy/) _\*\*\*\*_ provides step by step instructions on how to deploy an app on Akash using a desktop tool named Cloudmos Deploy.
+This [_**guide**_](/docs/deployments/akash-console/) _\*\*\*\*_ provides step by step instructions on how to deploy an app on Akash using a desktop tool named Cloudmos Deploy.
 
 ## Technical Support Channels
 

--- a/src/content/Docs/guides/tls-termination-of-akash-deployment/index.md
+++ b/src/content/Docs/guides/tls-termination-of-akash-deployment/index.md
@@ -40,7 +40,7 @@ Make sure to specify the hostname you control, in this example it is “ghost.ak
 
 When you deploy with 80/tcp port exposed in Akash, the nginx-ingress-controller on the provider will automatically get 443/tcp exposed too. This makes Full TLS termination possible.
 
-If you are not familiar with Akash deployments, visit the documentation for the desktop app [Cloudmos Deploy](/docs/deployments/cloudmos-deploy/) as an easy way to get started.
+If you are not familiar with Akash deployments, visit the documentation for the desktop app [Cloudmos Deploy](/docs/deployments/akash-console/) as an easy way to get started.
 
 ```
 ---

--- a/src/content/Docs/network-features/fractional-uakt/index.md
+++ b/src/content/Docs/network-features/fractional-uakt/index.md
@@ -16,7 +16,7 @@ In this guide we will use the Cloudmos Deploy tool to launch deployments using f
 
 For the purpose of demonstrating the use of fractional uAKT we will utilize the popular Hello World web application and SDL that can be found in the [Awesome Akash repository](https://github.com/akash-network/awesome-akash). The example SDL file will be modified to take advantage of the new fractional uAKT option.
 
-The [Cloudmos Deploy](/docs/deployments/cloudmos-deploy/) application will be used to launch the deployment.
+The [Cloudmos Deploy](/docs/deployments/akash-console/) application will be used to launch the deployment.
 
 ### **Example Fractional uAKT Use in Cloudmos Deploy**
 


### PR DESCRIPTION
PR for the docs to reference the akash console (formerly cloudmos deploy)


