### PR TITLE
Add Rango Exchange link

### DIFF
--- a/src/content/Token_Homepage/index.md
+++ b/src/content/Token_Homepage/index.md
@@ -100,6 +100,8 @@ buyingAKTSection:
     - row:
         - title: KuCoin
           link: "https://trade.kucoin.com/AKT-USDT"
+        - title: Rango Exchange
+          link: "https://app.rango.exchange/swap/BSC.BNB/AKASH.AKT"
 
     - row:
         - title: Crypto.com


### PR DESCRIPTION
Rango Exchange is a well known aggregator for evm, cosmos, ... chains and it supports Akash chain from the early stage.
As discussed [here](https://github.com/orgs/akash-network/discussions/495#discussioncomment-8696226), we would like to have Rango link at Akash website for decentralised buy options.

