### PR TITLE
fix: set correct url for project states

### DIFF
--- a/src/content/Development_Page/product-strategy/index.mdx
+++ b/src/content/Development_Page/product-strategy/index.mdx
@@ -193,6 +193,6 @@ Akash Network’s execution framework uses a community based development model t
 
 - Documented places to discuss/ publish/ comment/ review/ approve the specifications for each projects listed in #1 above. This is outlined in Data Organization and Repositories
 
-- States that a given project can be in. Outlined in [Project States](https://akash.network/)
+- States that a given project can be in. Outlined in [Project States](/development/current-projects/#project-states)
 
 - Meetings to regularly discuss prioritization of list of projects and meetings with individual project teams to make sure each project moves forward. Meetings page and notes will be documented in Github as noted in Data Organization and Repositories.

--- a/src/content/Development_Page/product-strategy/index.mdx
+++ b/src/content/Development_Page/product-strategy/index.mdx
@@ -193,6 +193,6 @@ Akash Network’s execution framework uses a community based development model t
 
 - Documented places to discuss/ publish/ comment/ review/ approve the specifications for each projects listed in #1 above. This is outlined in Data Organization and Repositories
 
-- States that a given project can be in. Outlined in [Project States](/development/current-projects/#project-states)
+- States that a given project can be in. Outlined in [Project States](/roadmap/2025)
 
 - Meetings to regularly discuss prioritization of list of projects and meetings with individual project teams to make sure each project moves forward. Meetings page and notes will be documented in Github as noted in Data Organization and Repositories.


### PR DESCRIPTION
Issue #745 

The project states link in the product strategy [page](https://akash.network/development/product-strategy/) is broken (links to homepage)

This PR changes the link to point to the correct section in the current projects page

