### PR TITLE
docs: Update the Akash CLI installation from source instructions

### DIFF
--- a/src/content/Docs/deployments/akash-cli/installation/index.mdx
+++ b/src/content/Docs/deployments/akash-cli/installation/index.mdx
@@ -231,7 +231,9 @@ terminal, or using source e.g. `source ~/.bashrc`
 
 ##### Installation
 
-The Akash CLI can be built as follows:
+First, check that [GOPATH](https://go.dev/wiki/GOPATH) is set correctly.
+
+The Akash CLI can then be built as follows:
 
 ``` bash
 git clone https://github.com/akash-network/provider.git
@@ -242,14 +244,9 @@ make install
 ```
 
 After the above steps are completed, the `provider-services`
-executable will be located at the following path within the
-provider repository.
+executable will be located at `$GOPATH/bin`
 
-`<project root>.cache/bin/provider-services`
-
-It can now be copied to a location that is present in `PATH`
-e.g. `usr/local/bin` for convenience.
-
+The location above can be added to your `PATH` for convenience.
   </TabContent>
   </TabsWrapper>
 

--- a/src/content/Docs/deployments/akash-cli/installation/index.mdx
+++ b/src/content/Docs/deployments/akash-cli/installation/index.mdx
@@ -238,7 +238,11 @@ The Akash CLI can then be built as follows:
 ``` bash
 git clone https://github.com/akash-network/provider.git
 cd provider
-direnv allow  # some packages may be downloaded
+direnv allow  # some network activity may be observed
+AKASH_NET="https://raw.githubusercontent.com/akash-network/net/main/mainnet"
+AKASH_VERSION="$(curl -s https://api.github.com/repos/akash-network/provider/releases/latest | jq -r '.tag_name')"
+git checkout $AKASH_VERSION
+direnv reload
 make install
 
 ```

--- a/src/content/Docs/deployments/akash-cli/installation/index.mdx
+++ b/src/content/Docs/deployments/akash-cli/installation/index.mdx
@@ -172,21 +172,83 @@ v0.4.7
   <TabContent value="Source">
   #### From Source
 
-Installing Akash suite from source:
+##### Prerequisites
+
+The following prerequisites are required:
+
+- Go 1.21.0 or later
+- GNU Make 4.0 or later
+- Bash 4.0 or later
+- [direnv](https://direnv.net/docs/installation.html) 2.32.x or later
+- wget
+- unzip
+- curl
+- npm
+- jq
+- git
+- realpath and readlink (may be installed via GNU coreutils)
+- gnu-getopt for macOS (`brew install gnu-getopt`)
+
+These can be installed using the relevant package manager your OS
+e.g. Homebrew for macOS or Apt for Debian based systems.
+
+In macOS, the default version is usually outdated. An updated version
+can be installed via Homebrew, and the `PATH` adjusted to point to it as
+follows.
+
+```bash
+# Install using Homebrew
+brew install make
+
+# The new GNU Make will be installed as 'gmake'
+# Add this to your ~/.zshrc or ~/.bashrc to use it as 'make':
+export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+```
+
+In case of any issues, checkout the more detailed [docs](https://github.com/akash-network/provider/blob/main/CONTRIBUTING.md) in the provider
+repository.
+
+##### Direnv setup
+
+Check that the `direnv` version (`direnv --version`) installed meets
+the minimum version requirement. In case the version installed by the
+package manager is outdated, prebuild binaries can be used
+instead. See the direnv instructions
+[here](https://direnv.net/docs/installation.html)
+
+After `direnv` is installed it needs to be hooked to your shell. For
+example:
+
+```bash
+# For zsh (add to ~/.zshrc):
+eval "$(direnv hook zsh)"
+
+# For bash (add to ~/.bashrc):
+eval "$(direnv hook bash)"
+```
+The shell config needs to be reread. This can be done by opening a new
+terminal, or using source e.g. `source ~/.bashrc`
+
+##### Installation
+
+The Akash CLI can be built as follows:
+
+``` bash
+git clone https://github.com/akash-network/provider.git
+cd provider
+direnv allow  # some packages may be downloaded
+make install
 
 ```
-$ go get -d github.com/akash-network/provider
-$ cd $GOPATH/src/github.com/akash-network/provider
-$ AKASH_NET="https://raw.githubusercontent.com/akash-network/net/main/mainnet"
-$ AKASH_VERSION="$(curl -s https://api.github.com/repos/akash-network/provider/releases/latest | jq -r '.tag_name')"
-$ git checkout "v$AKASH_VERSION"
-$ make deps-install
-$ make install
-```
 
-Akash is developed and tested with [golang 1.16+](https://golang.org/). Building requires a working [golang](https://golang.org/) installation, a properly set `GOPATH`, and `$GOPATH/bin` present in `$PATH`.
+After the above steps are completed, the `provider-services`
+executable will be located at the following path within the
+provider repository.
 
-Once you have the dependencies properly setup, download and build `akash` using `make install`
+`<project root>.cache/bin/provider-services`
+
+It can now be copied to a location that is present in `PATH`
+e.g. `usr/local/bin` for convenience.
 
   </TabContent>
   </TabsWrapper>

--- a/src/content/Docs/deployments/akash-cli/installation/index.mdx
+++ b/src/content/Docs/deployments/akash-cli/installation/index.mdx
@@ -192,7 +192,7 @@ The following prerequisites are required:
 These can be installed using the relevant package manager your OS
 e.g. Homebrew for macOS or Apt for Debian based systems.
 
-In macOS, the default version is usually outdated. An updated version
+In macOS, the default `make` version is usually outdated. An updated version
 can be installed via Homebrew, and the `PATH` adjusted to point to it as
 follows.
 

--- a/src/content/Docs/deployments/sandbox/installation/index.mdx
+++ b/src/content/Docs/deployments/sandbox/installation/index.mdx
@@ -189,21 +189,83 @@ v0.4.6
 <TabContent value="Source">
 #### From Source
 
-Installing Akash suite from source:
+##### Prerequisites
+
+The following prerequisites are required:
+
+- Go 1.21.0 or later
+- GNU Make 4.0 or later
+- Bash 4.0 or later
+- [direnv](https://direnv.net/docs/installation.html) 2.32.x or later
+- wget
+- unzip
+- curl
+- npm
+- jq
+- git
+- realpath and readlink (may be installed via GNU coreutils)
+- gnu-getopt for macOS (`brew install gnu-getopt`)
+
+These can be installed using the relevant package manager your OS
+e.g. Homebrew for macOS or Apt for Debian based systems.
+
+In macOS, the default version is usually outdated. An updated version
+can be installed via Homebrew, and the `PATH` adjusted to point to it as
+follows.
+
+```bash
+# Install using Homebrew
+brew install make
+
+# The new GNU Make will be installed as 'gmake'
+# Add this to your ~/.zshrc or ~/.bashrc to use it as 'make':
+export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+```
+
+In case of any issues, checkout the more detailed [docs](https://github.com/akash-network/provider/blob/main/CONTRIBUTING.md) in the provider
+repository.
+
+##### Direnv setup
+
+Check that the `direnv` version (`direnv --version`) installed meets
+the minimum version requirement. In case the version installed by the
+package manager is outdated, prebuild binaries can be used
+instead. See the direnv instructions
+[here](https://direnv.net/docs/installation.html)
+
+After `direnv` is installed it needs to be hooked to your shell. For
+example:
+
+```bash
+# For zsh (add to ~/.zshrc):
+eval "$(direnv hook zsh)"
+
+# For bash (add to ~/.bashrc):
+eval "$(direnv hook bash)"
+```
+The shell config needs to be reread. This can be done by opening a new
+terminal, or using source e.g. `source ~/.bashrc`
+
+##### Installation
+
+The Akash CLI can be built as follows:
+
+``` bash
+git clone https://github.com/akash-network/provider.git
+cd provider
+direnv allow  # some packages may be downloaded
+make install
 
 ```
-$ go get -d github.com/akash-network/provider
-$ cd $GOPATH/src/github.com/akash-network/provider
-$ AKASH_NET="https://raw.githubusercontent.com/akash-network/net/main/mainnet"
-$ AKASH_VERSION="$(curl -s https://api.github.com/repos/akash-network/provider/releases/latest | jq -r '.tag_name')"
-$ git checkout "v$AKASH_VERSION"
-$ make deps-install
-$ make install
-```
 
-Akash is developed and tested with [golang 1.16+](https://golang.org/). Building requires a working [golang](https://golang.org/) installation, a properly set `GOPATH`, and `$GOPATH/bin` present in `$PATH`.
+After the above steps are completed, the `provider-services`
+executable will be located at the following path within the
+provider repository.
 
-Once you have the dependencies properly setup, download and build `akash` using `make install`
+`<project root>.cache/bin/provider-services`
+
+It can now be copied to a location that is present in `PATH`
+e.g. `usr/local/bin` for convenience.
 
 </TabContent>
 </TabsWrapper>

--- a/src/content/Docs/deployments/sandbox/installation/index.mdx
+++ b/src/content/Docs/deployments/sandbox/installation/index.mdx
@@ -209,7 +209,7 @@ The following prerequisites are required:
 These can be installed using the relevant package manager your OS
 e.g. Homebrew for macOS or Apt for Debian based systems.
 
-In macOS, the default version is usually outdated. An updated version
+In macOS, the default `make` version is usually outdated. An updated version
 can be installed via Homebrew, and the `PATH` adjusted to point to it as
 follows.
 

--- a/src/content/Docs/deployments/sandbox/installation/index.mdx
+++ b/src/content/Docs/deployments/sandbox/installation/index.mdx
@@ -255,7 +255,11 @@ The Akash CLI can then be built as follows:
 ``` bash
 git clone https://github.com/akash-network/provider.git
 cd provider
-direnv allow  # some packages may be downloaded
+direnv allow  # some network activity may be observed
+AKASH_NET="https://raw.githubusercontent.com/akash-network/net/main/mainnet"
+AKASH_VERSION="$(curl -s https://api.github.com/repos/akash-network/provider/releases/latest | jq -r '.tag_name')"
+git checkout $AKASH_VERSION
+direnv reload
 make install
 
 ```

--- a/src/content/Docs/deployments/sandbox/installation/index.mdx
+++ b/src/content/Docs/deployments/sandbox/installation/index.mdx
@@ -248,7 +248,9 @@ terminal, or using source e.g. `source ~/.bashrc`
 
 ##### Installation
 
-The Akash CLI can be built as follows:
+First, check that [GOPATH](https://go.dev/wiki/GOPATH) is set correctly.
+
+The Akash CLI can then be built as follows:
 
 ``` bash
 git clone https://github.com/akash-network/provider.git
@@ -259,13 +261,9 @@ make install
 ```
 
 After the above steps are completed, the `provider-services`
-executable will be located at the following path within the
-provider repository.
+executable will be located at `$GOPATH/bin`
 
-`<project root>.cache/bin/provider-services`
-
-It can now be copied to a location that is present in `PATH`
-e.g. `usr/local/bin` for convenience.
+The location above can be added to your `PATH` for convenience.
 
 </TabContent>
 </TabsWrapper>


### PR DESCRIPTION
Closes #773 

Currently on the website, the instructions for installing Akash CLI from source in the [deployments][0] and [sandbox][1] sections are outdated.

This PR updates the instructions to work with more up to date versions of Go and the current state of the [provider][3] repository.

[0]: https://akash.network/docs/deployments/akash-cli/installation/

[1]: https://akash.network/docs/deployments/sandbox/installation/

[3]: https://github.com/akash-network/provider