### PR TITLE
fix: prevent blog API crashes when contributors/tags are empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ pnpm-debug.log*
 
 # Rough work file
 broken-links-notes.md
+
+# VS Code
+.vscode/

--- a/src/pages/api/search/blog.json.ts
+++ b/src/pages/api/search/blog.json.ts
@@ -19,8 +19,8 @@ async function getBlogPageContent() {
       month: "short",
       day: "numeric",
     }),
-    contributor: content.data.contributors[0],
-    tag: content.data.tags[0],
+    contributor: content.data.contributors?.[0] || null,
+    tag: content.data.tags?.[0] || null,
   }));
 }
 


### PR DESCRIPTION
Added safe array access using optional chaining (?.[0]) for contributors and tags. With this change it falls back to `null` instead of crashing when arrays are empty.

Closes #896.