### PR TITLE
chore: unify robots and fix sitemap freshness, move types to devDeps

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,9 +18,7 @@ export default defineConfig({
   },
   integrations: [
     tailwind(),
-    sitemap({
-      lastmod: new Date("2024-06-27"),
-    }),
+    sitemap(),
     react(),
     astroExpressiveCode({
       themes: ["light-plus", "dark-plus"],

--- a/package.json
+++ b/package.json
@@ -42,12 +42,8 @@
     "@tailwindcss/typography": "^0.5.10",
     "@tanstack/react-query": "^4.29.7",
     "@tanstack/react-query-devtools": "^4.32.6",
-    "@types/lodash": "^4.17.7",
-    "@types/react": "^18.0.21",
-    "@types/react-dom": "^18.0.6",
     "astro": "^4.0.7",
     "astro-expressive-code": "^0.30.1",
-    "astro-robots-txt": "^1.0.0",
     "axios": "^1.6.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
@@ -82,6 +78,9 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.7",
+    "@types/react": "^18.0.21",
+    "@types/react-dom": "^18.0.6",
     "@types/react-simple-maps": "^3.0.4",
     "prettier": "^3.0.3",
     "prettier-plugin-astro": "^0.12.0",

--- a/src/components/acc-2025/Recap.tsx
+++ b/src/components/acc-2025/Recap.tsx
@@ -1,5 +1,5 @@
 import { acc2025 } from "@/components/acc-2025/acc-2025";
-import classNames from "classnames";
+import clsx from "clsx";
 import { ArrowUpCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 const Recap = ({ type }: { type: "button" | "image" }) => {
@@ -70,7 +70,7 @@ const Recap = ({ type }: { type: "button" | "image" }) => {
       )}
 
       <div
-        className={classNames(
+        className={clsx(
           "fixed inset-0 z-50 bg-black/50 transition-opacity duration-300",
           isOpen ? "opacity-100" : "pointer-events-none opacity-0",
         )}
@@ -78,7 +78,7 @@ const Recap = ({ type }: { type: "button" | "image" }) => {
       />
 
       <div
-        className={classNames(
+        className={clsx(
           "fixed left-1/2 top-1/2 z-50 w-[90%] max-w-4xl -translate-x-1/2 -translate-y-1/2 transform select-none transition-all duration-300",
           isOpen
             ? "scale-100 opacity-100"


### PR DESCRIPTION
 - Remove static sitemap `lastmod` to avoid stale SEO signals.  
  - Keep single robots.txt source, remove `astro-robots-txt` plugin.  
  - Move all `@types/*` dependencies to devDependencies to reduce production size.  
  - Verify builds and update lockfile.  