### PR TITLE
blog: add student ambassador program blog post

### DIFF
--- a/src/content/Blog/from-pilot-to-scale-building-the-akash-student-ambassador-program/index.md
+++ b/src/content/Blog/from-pilot-to-scale-building-the-akash-student-ambassador-program/index.md
@@ -1,0 +1,168 @@
+---
+title: "From Pilot to Scale: Building the Akash Student Ambassador Program"
+description: "A look at what our first cohort of student ambassadors accomplished and how we're scaling the program with Cohort 2 — structured contribution paths, real deployments, and builders who operate like contributors, not interns."
+
+pubDate: "2026-03-10"
+draft: false
+archive: false
+
+categories:
+  - Community
+
+tags:
+  - Community
+
+contributors:
+  - Zach Horn
+
+bannerImage: ./banner-image.png
+---
+
+Last fall, we launched something simple:
+
+**What if we treated student ambassadors like operators instead of interns?**
+
+Not Discord lurkers.
+Or social media promoters.
+And definitely not resume-fillers.
+
+But real contributors to decentralized infrastructure.
+
+That question became the foundation of the Akash Student Ambassador Program.
+
+Today, as we launch our second cohort, I want to highlight what our first group accomplished — and how we're scaling what worked.
+
+## Cohort 1: The Pilot (Fall 2025)
+
+The first cohort was intentionally small:
+
+- 4 universities
+- 7 ambassadors
+- One unified contribution structure
+- In-person onboarding in Austin, Texas
+
+With just seven students, the impact was disproportionate.
+
+### Technical Contributions
+
+Cohort 1 didn't just talk about decentralized cloud, they built on it.
+
+- Shipped an open-source project connecting Zcash to Akash's decentralized cloud infrastructure
+- Published a guide on self-hosting the cheapest n8n server
+- Created a walkthrough on hosting Clawdbot for free
+
+These weren't hypothetical exercises. They were real deployments, documented publicly, and accessible to the broader ecosystem.
+
+### Events & Campus Activation
+
+Across a single semester, ambassadors hosted:
+
+- 6 student-run events
+- Across Princeton, USC, UT Austin, and Cornell
+- With an average attendance of ~30 students per event
+
+These ranged from introductory sessions on decentralized cloud to live deployment workshops where students walked away having actually used Akash.
+
+Most events were collaborative, partnering with AI and Blockchain clubs to reach highly technical audiences.
+
+With just seven ambassadors, we activated four major universities and brought dozens of new builders into the ecosystem.
+
+### Content & Thought Leadership
+
+Cohort 1 also began building their public proof of work.
+
+Students wrote blog posts and articles on:
+
+- Decentralized vs. centralized cloud
+- AI training infrastructure
+- Startup experimentation
+- Compute economics
+
+They weren't just learning, they were teaching.
+
+And that matters.
+
+Because decentralized infrastructure adoption doesn't scale through ads.
+It scales through builders explaining it to other builders.
+
+## What We Learned
+
+The pilot taught us something important:
+
+**One-size-fits-all expectations limit excellence.**
+
+Some ambassadors are deeply technical.
+Some are natural educators.
+Some are community architects.
+Some are content operators.
+
+When everyone is expected to do everything, specialization — and therefore output — suffers.
+
+We also learned:
+
+- Structure drives consistency.
+- Monthly deliverables outperform vague expectations.
+- Recognition and visibility matter as much as incentives.
+- Students perform best when they have defined lanes and measurable output.
+
+So for Cohort 2, we rebuilt the system.
+
+## Cohort 2: The Evolution (Spring 2026)
+
+This semester, the program scales intentionally:
+
+- Expanded to multiple U.S. and international universities
+- 15 ambassadors
+- More diverse academic and technical backgrounds
+
+But the biggest upgrade isn't size.
+
+It's structure.
+
+### Four Contribution Paths
+
+Instead of a unified model, ambassadors are now assigned to two defined lanes:
+
+- Technical Builds & Demos
+- Events & Workshops
+- Content Creation
+- Community Growth
+
+Each ambassador owns two paths.
+Each ambassador delivers at least two measurable contributions per month.
+
+The result?
+
+Clear accountability.
+Clear specialization.
+Clear output.
+
+Every ambassador leaves with:
+
+- Public proof of work
+- Technical deployments
+- Event leadership experience
+- A content portfolio
+- Ecosystem relationships
+
+That's leverage.
+
+### Meet Cohort 2: Builders, Not Observers
+
+Cohort 2 isn't a typical group of student ambassadors.
+
+It's a concentrated group of operators already building at the edge of AI, blockchain, and decentralized infrastructure.
+
+Across this cohort, you'll find:
+
+- Senior leadership across major university blockchain organizations
+- Hackathon winners shipping real AI products
+- Former product leadership from Coinbase
+- Software engineering experience at Gemini
+- AI founders, robotics researchers, and community architects
+
+These aren't students "exploring Web3."
+
+They're already inside it.
+
+And this semester, they're building on decentralized cloud. Stay tuned and follow their journey!


### PR DESCRIPTION
## Summary
- Adds new blog post: "From Pilot to Scale: Building the Akash Student Ambassador Program"
- Covers Cohort 1 results (Fall 2025) and Cohort 2 launch (Spring 2026)
- Highlights technical contributions, campus events, content output, and the new four-path contribution structure

## Notes
- **Banner image still needed** — `banner-image.png` is referenced in frontmatter but not yet added
- Contributor set to Zach Horn — update if needed
- Category/tag set to "Community"

## Test plan
- [ ] Verify blog post renders correctly on `/blog` listing
- [ ] Verify individual post page at `/blog/from-pilot-to-scale-building-the-akash-student-ambassador-program`
- [ ] Add banner image before merging