### PR TITLE
docs: replace deprecated SDL class with generateManifest

### DIFF
--- a/src/content/Docs/api-documentation/sdk/api-reference/index.mdx
+++ b/src/content/Docs/api-documentation/sdk/api-reference/index.mdx
@@ -112,18 +112,36 @@ func main() {
     {
       language: "typescript",
       label: "TypeScript",
-      code: `import { SDL } from "@akashnetwork/chain-sdk";
+      code: `import { generateManifest, generateManifestVersion, yaml, type SDLInput } from "@akashnetwork/chain-sdk";
 
-// Parse SDL from YAML string
-const sdl = SDL.fromString(yamlString, "beta3", "mainnet");
+// Define SDL using the yaml template tag
+const sdl: SDLInput = yaml\`
+version: "2.0"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+\`;
 
-// Get deployment manifest
-const manifest = sdl.manifest();
-// Returns: Array of deployment groups with service definitions
+// Generate manifest and deployment groups
+const result = generateManifest(sdl);
 
-// Get deployment groups
-const groups = sdl.groups();
-// Returns: Array of GroupSpec objects for blockchain submission`
+if (!result.ok) {
+  console.error("Validation errors:", result.value);
+} else {
+  // Get deployment manifest (Array of groups with service definitions)
+  const manifest = result.value.groups;
+
+  // Get deployment groups (Array of GroupSpec for blockchain submission)
+  const groupSpecs = result.value.groupSpecs;
+
+  // Get SDL version hash (SHA-256)
+  const version = await generateManifestVersion(manifest);
+}`
     },
     {
       language: "go",
@@ -150,13 +168,16 @@ version, err := sdlDoc.Version()
   ]}
 />
 
-**TypeScript Methods:**
-- `SDL.fromString(yaml, version?, networkId?)` - Parse SDL from YAML
-  - `yaml`: YAML string
-  - `version`: "beta2" | "beta3" (default: "beta3")
+**TypeScript Functions:**
+- `generateManifest(sdl, networkId?)` - Generate manifest and deployment groups
+  - `sdl`: `SDLInput` - Parsed SDL object (use the `yaml` template tag)
   - `networkId`: "mainnet" | "testnet" | "sandbox" (default: "mainnet")
-- `sdl.manifest()` - Get deployment manifest
-- `sdl.groups()` - Get deployment groups for blockchain
+  - Returns `{ ok: true, value: { groups, groupSpecs } }` on success
+  - Returns `{ ok: false, value: ValidationError[] }` on validation failure
+- `generateManifestVersion(manifest)` - Get SHA-256 hash of manifest
+  - `manifest`: `Manifest` - The `groups` array from `generateManifest` result
+  - Returns `Promise<Uint8Array>`
+- `` yaml`...` `` - Template tag for defining SDL with interpolation support
 
 **Go Functions:**
 - `sdl.ReadFile(path)` - Read SDL from file
@@ -240,10 +261,16 @@ dep, err := client.Query().Deployment().Deployment(ctx,
     {
       language: "typescript",
       label: "TypeScript",
-      code: `import { SDL } from "@akashnetwork/chain-sdk";
+      code: `import { generateManifest, yaml, type SDLInput } from "@akashnetwork/chain-sdk";
 
-const sdl = SDL.fromString(yamlString);
-const groups = sdl.groups();
+const sdl: SDLInput = yaml\`...\`; // Your SDL definition
+const result = generateManifest(sdl);
+
+if (!result.ok) {
+  throw new Error("SDL validation failed: " + JSON.stringify(result.value));
+}
+
+const { groupSpecs } = result.value;
 
 // Get current block height for dseq
 const status = await sdk.cosmos.base.tendermint.v1beta1.getLatestBlock({});
@@ -253,12 +280,12 @@ const dseq = status.block.header.height;
 const accounts = await wallet.getAccounts();
 
 // Create deployment
-const result = await sdk.akash.deployment.v1beta4.createDeployment({
+const deployResult = await sdk.akash.deployment.v1beta4.createDeployment({
   id: {
     owner: accounts[0].address,
     dseq: dseq
   },
-  groups: groups,
+  groups: groupSpecs,
   deposit: {
     denom: "uakt",
     amount: "5000000" // 5 AKT
@@ -311,15 +338,21 @@ resp, err := client.Tx().BroadcastMsgs(ctx, []sdk.Msg{msg})`
     {
       language: "typescript",
       label: "TypeScript",
-      code: `const sdl = SDL.fromString(newYamlString);
-const groups = sdl.groups();
+      code: `import { generateManifest, yaml, type SDLInput } from "@akashnetwork/chain-sdk";
 
-const result = await sdk.akash.deployment.v1beta4.updateDeployment({
+const newSdl: SDLInput = yaml\`...\`; // Your updated SDL definition
+const result = generateManifest(newSdl);
+
+if (!result.ok) {
+  throw new Error("SDL validation failed: " + JSON.stringify(result.value));
+}
+
+const updateResult = await sdk.akash.deployment.v1beta4.updateDeployment({
   id: {
     owner: accounts[0].address,
     dseq: "1234567"
   },
-  groups: groups
+  groups: result.value.groupSpecs
 });`
     },
     {

--- a/src/content/Docs/api-documentation/sdk/examples/index.mdx
+++ b/src/content/Docs/api-documentation/sdk/examples/index.mdx
@@ -135,9 +135,9 @@ func main() {
     {
       language: "typescript",
       label: "TypeScript",
-      code: `import { SDL } from "@akashnetwork/chain-sdk";
+      code: `import { generateManifest, generateManifestVersion, yaml, type SDLInput } from "@akashnetwork/chain-sdk";
 
-const yaml = \`
+const sdl: SDLInput = yaml\`
 version: "2.0"
 services:
   web:
@@ -170,16 +170,22 @@ deployment:
       count: 1
 \`;
 
-// Parse SDL from YAML string
-const sdl = SDL.fromString(yaml, "beta3", "mainnet");
+// Generate manifest and deployment groups
+const result = generateManifest(sdl);
 
-// Get deployment manifest
-const manifest = sdl.manifest();
-console.log("Manifest:", manifest);
+if (!result.ok) {
+  console.error("Validation errors:", result.value);
+} else {
+  // Deployment manifest
+  console.log("Manifest:", result.value.groups);
 
-// Get deployment groups
-const groups = sdl.groups();
-console.log("Groups:", groups);`
+  // Deployment groups for blockchain submission
+  console.log("Group Specs:", result.value.groupSpecs);
+
+  // Get SDL version hash (SHA-256)
+  const version = await generateManifestVersion(result.value.groups);
+  console.log("Version:", version);
+}`
     }
   ]}
 />
@@ -415,10 +421,10 @@ func createDeployment(ctx context.Context, client v1beta3.Client, sdlPath string
     {
       language: "typescript",
       label: "TypeScript",
-      code: `import { SDL } from "@akashnetwork/chain-sdk";
+      code: `import { generateManifest, yaml, type SDLInput } from "@akashnetwork/chain-sdk";
 
-// Parse SDL
-const yaml = \`
+// Define SDL
+const sdl: SDLInput = yaml\`
 version: "2.0"
 services:
   web:
@@ -451,8 +457,13 @@ deployment:
       count: 1
 \`;
 
-const sdl = SDL.fromString(yaml, "beta3", "mainnet");
-const groups = sdl.groups();
+const result = generateManifest(sdl);
+
+if (!result.ok) {
+  throw new Error("SDL validation failed: " + JSON.stringify(result.value));
+}
+
+const { groupSpecs } = result.value;
 
 // Get current block height for dseq
 const status = await sdk.cosmos.base.tendermint.v1beta1.getLatestBlock({});
@@ -462,12 +473,12 @@ const dseq = status.block.header.height;
 const accounts = await wallet.getAccounts();
 
 // Create deployment
-const result = await sdk.akash.deployment.v1beta4.createDeployment({
+const deployResult = await sdk.akash.deployment.v1beta4.createDeployment({
   id: {
     owner: accounts[0].address,
     dseq: dseq
   },
-  groups: groups,
+  groups: groupSpecs,
   deposit: {
     denom: "uakt",
     amount: "5000000" // 5 AKT
@@ -475,7 +486,7 @@ const result = await sdk.akash.deployment.v1beta4.createDeployment({
   depositor: accounts[0].address
 });
 
-console.log("Deployment created:", result);`
+console.log("Deployment created:", deployResult);`
     }
   ]}
 />
@@ -866,16 +877,16 @@ func useJWT(token string, dseq uint64) {
       language: "typescript",
       label: "TypeScript",
       code: `import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
-import { createChainNodeSDK, SDL } from "@akashnetwork/chain-sdk";
+import { createChainNodeSDK, generateManifest, yaml, type SDLInput } from "@akashnetwork/chain-sdk";
 
 async function deployToAkash() {
   // 1. Initialize wallet
   const mnemonic = "your mnemonic phrase here";
-  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(mnemonic, { 
-    prefix: "akash" 
+  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(mnemonic, {
+    prefix: "akash"
   });
   const accounts = await wallet.getAccounts();
-  
+
   // 2. Initialize SDK
   const sdk = createChainNodeSDK({
     query: {
@@ -886,9 +897,9 @@ async function deployToAkash() {
       signer: wallet,
     },
   });
-  
-  // 3. Parse SDL
-  const yaml = \`
+
+  // 3. Define and generate manifest from SDL
+  const sdl: SDLInput = yaml\`
 version: "2.0"
 services:
   web:
@@ -920,21 +931,26 @@ deployment:
       profile: web
       count: 1
 \`;
-  
-  const sdl = SDL.fromString(yaml, "beta3", "mainnet");
-  const groups = sdl.groups();
-  
+
+  const result = generateManifest(sdl);
+
+  if (!result.ok) {
+    throw new Error("SDL validation failed: " + JSON.stringify(result.value));
+  }
+
+  const { groupSpecs } = result.value;
+
   // 4. Get current block height
   const status = await sdk.cosmos.base.tendermint.v1beta1.getLatestBlock({});
   const dseq = status.block.header.height;
-  
+
   // 5. Create deployment
   const deployment = await sdk.akash.deployment.v1beta4.createDeployment({
     id: {
       owner: accounts[0].address,
       dseq: dseq
     },
-    groups: groups,
+    groups: groupSpecs,
     deposit: {
       denom: "uakt",
       amount: "5000000"

--- a/src/content/Docs/api-documentation/sdk/quick-start/index.mdx
+++ b/src/content/Docs/api-documentation/sdk/quick-start/index.mdx
@@ -56,7 +56,7 @@ Before you begin, ensure you have:
       language: "typescript",
       label: "TypeScript",
       code: `import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
-import { createChainNodeSDK, SDL } from "@akashnetwork/chain-sdk";
+import { createChainNodeSDK, generateManifest, yaml, type SDLInput } from "@akashnetwork/chain-sdk";
 
 // Initialize wallet from mnemonic
 const mnemonic = "your mnemonic phrase here";
@@ -192,10 +192,10 @@ deployment:
     {
       language: "typescript",
       label: "TypeScript",
-      code: `import { SDL } from "@akashnetwork/chain-sdk";
+      code: `import { generateManifest, yaml, type SDLInput } from "@akashnetwork/chain-sdk";
 
-// Read SDL file (or use string directly)
-const yamlContent = \`
+// Define SDL using the yaml template tag
+const sdl: SDLInput = yaml\`
 version: "2.0"
 services:
   web:
@@ -228,9 +228,14 @@ deployment:
       count: 1
 \`;
 
-// Parse SDL
-const sdl = SDL.fromString(yamlContent, "beta3", "sandbox");
-const groups = sdl.groups();
+// Generate manifest and deployment groups
+const result = generateManifest(sdl, "sandbox");
+
+if (!result.ok) {
+  throw new Error("SDL validation failed: " + JSON.stringify(result.value));
+}
+
+const { groups, groupSpecs } = result.value;
 
 console.log("SDL parsed successfully");
 
@@ -246,7 +251,7 @@ const deployment = await sdk.akash.deployment.v1beta4.createDeployment({
     owner: accounts[0].address,
     dseq: dseq
   },
-  groups: groups,
+  groups: groupSpecs,
   deposit: {
     denom: "uakt",
     amount: "5000000" // 5 AKT deposit
@@ -472,8 +477,8 @@ const token = await tokenManager.generateToken({
   leases: { access: "full" }
 });
 
-// Get manifest from SDL
-const manifest = sdl.manifest();
+// Use manifest from earlier generateManifest result (groups = manifest)
+const manifest = groups;
 
 // Send manifest to provider
 const providerUrl = selectedBid.bidId.provider; // Get provider URL from chain


### PR DESCRIPTION
## Why

The `SDL` class (`SDL.fromString`, `sdl.manifest()`, `sdl.groups()`) in `@akashnetwork/chain-sdk` is deprecated. The SDK now exposes standalone functions — `generateManifest`, `generateManifestVersion`, and a `yaml` template tag — as the recommended API for working with SDL definitions. Keeping the docs aligned with the current SDK avoids confusion for developers integrating with Akash.

## What

- Replaced all TypeScript `SDL` class usage with `generateManifest`, `generateManifestVersion`, `yaml` template tag, and `SDLInput` type across SDK docs (api-reference, quick-start, examples)
- Updated API reference method signatures and descriptions to document the new functions and their return types (`{ ok, value: { groups, groupSpecs } }`)
- Removed explicit `"mainnet"` network parameter from examples since it is the default


🤖 Generated with [Claude Code](https://claude.com/claude-code)