### PR TITLE
Remove announcement banner

### DIFF
--- a/src/content/Homepage/index.md
+++ b/src/content/Homepage/index.md
@@ -1,8 +1,4 @@
 ---
-advert:
-  title: "BME and WASM Smart Contracts are Now Live."
-  link: "/"
-
 # hero section content
 heroSection:
   title: The <span class="text-[#8C8E91] not-italic">Decentralized<br class="md:hidden" /> Cloud <br class="md:block hidden" />Built for </span><br class="md:hidden"/> AI's Next Frontier

--- a/src/utils/schema/homepage.ts
+++ b/src/utils/schema/homepage.ts
@@ -3,10 +3,12 @@ import { defineCollection, z } from "astro:content";
 export const homePageSchema = defineCollection({
   schema: ({ image }) => {
     return z.object({
-      advert: z.object({
-        title: z.string(),
-        link: z.string(),
-      }),
+      advert: z
+        .object({
+          title: z.string(),
+          link: z.string(),
+        })
+        .optional(),
       heroSection: z.object({
         title: z.string(),
         description: z.string(),


### PR DESCRIPTION
## Summary

- Removes the `advert` frontmatter from `src/content/Homepage/index.md` so no announcement banner is displayed
- Makes the `advert` field optional in the homepage schema so the site builds cleanly without it

## Test plan

- [ ] Verify the announcement banner no longer appears on the homepage
- [ ] Verify no build errors from the schema change