### PR TITLE
fix(docs): drop article overflow-x-auto that broke sticky right column

### DIFF
--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -107,7 +107,7 @@ const lines = page?.body
 
           <div class="my-5 border-b md:my-10"></div>
 
-          <article class={`${docsProseClasses} overflow-x-auto`}>
+          <article class={docsProseClasses}>
             <Content />
           </article>
           <div class="mt-5 border-y py-5 md:mt-10 md:px-2">


### PR DESCRIPTION
The docs page wrapper applied overflow-x-auto on the <article> element to
contain wide content. Any non-visible overflow on an ancestor creates a
new containing block for position:sticky, so the SDL reference layout's
right code panel never actually stuck to the viewport — it scrolled away
with the rest of the article.

The prose classes already handle per-element overflow for the widest
content types (prose-pre:overflow-x-auto, prose-table:overflow-x-auto),
so the outer wrapper was redundant. Removing it restores sticky behavior
for the reference layout without losing horizontal scrolling on long
code blocks or tables.

Signed-off-by: Joseph Chalabi <chalabi.joseph@gmail.com>
