### PR TITLE
docs(console-api): sync managed-wallet API docs with code

### DIFF
--- a/src/content/Docs/api-documentation/console-api/api-reference/index.md
+++ b/src/content/Docs/api-documentation/console-api/api-reference/index.md
@@ -114,13 +114,13 @@ Create a new deployment from an SDL manifest and fund its escrow.
 | ------------ | -------- | ------ | -------- | ---------------------------------------------------------- |
 | x-api-key    | header   | string | yes      | Your API key                                               |
 | data.sdl     | body     | string | yes      | Deployment manifest in SDL (YAML) format, as a JSON string |
-| data.deposit | body     | number | yes      | Initial escrow deposit in USD, for example `5.5`           |
+| data.deposit | body     | number | yes      | Initial escrow deposit in USD. Minimum `0.5`               |
 
 ```bash
 curl -X POST https://console-api.akash.network/v1/deployments \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{ "data": { "sdl": "version: \"2.0\"\n...", "deposit": 5.5 } }'
+  -d '{ "data": { "sdl": "version: \"2.0\"\n...", "deposit": 0.5 } }'
 ```
 
 ```javascript
@@ -130,7 +130,7 @@ const res = await fetch("https://console-api.akash.network/v1/deployments", {
     "x-api-key": process.env.AKASH_API_KEY,
     "Content-Type": "application/json",
   },
-  body: JSON.stringify({ data: { sdl: sdlString, deposit: 5.5 } }),
+  body: JSON.stringify({ data: { sdl: sdlString, deposit: 0.5 } }),
 });
 const { data } = await res.json();
 ```
@@ -282,17 +282,17 @@ Response `200 OK` is the same shape as `GET /v1/deployments/{dseq}` — see belo
 
 Add USD funds to a deployment's escrow to extend its runtime.
 
-| Field        | Location | Type   | Required | Description                             |
-| ------------ | -------- | ------ | -------- | --------------------------------------- |
-| x-api-key    | header   | string | yes      | Your API key                            |
-| data.dseq    | body     | string | yes      | Deployment sequence ID                  |
-| data.deposit | body     | number | yes      | Deposit amount in USD, for example `10` |
+| Field        | Location | Type   | Required | Description                          |
+| ------------ | -------- | ------ | -------- | ------------------------------------ |
+| x-api-key    | header   | string | yes      | Your API key                         |
+| data.dseq    | body     | string | yes      | Deployment sequence ID               |
+| data.deposit | body     | number | yes      | Deposit amount in USD. Minimum `0.5` |
 
 ```bash
 curl -X POST https://console-api.akash.network/v1/deposit-deployment \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{ "data": { "dseq": "1234567", "deposit": 10 } }'
+  -d '{ "data": { "dseq": "1234567", "deposit": 0.5 } }'
 ```
 
 ```javascript
@@ -304,7 +304,7 @@ const res = await fetch(
       "x-api-key": process.env.AKASH_API_KEY,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ data: { dseq, deposit: 10 } }),
+    body: JSON.stringify({ data: { dseq, deposit: 0.5 } }),
   },
 );
 const { data } = await res.json();

--- a/src/content/Docs/api-documentation/console-api/api-reference/index.md
+++ b/src/content/Docs/api-documentation/console-api/api-reference/index.md
@@ -7,15 +7,15 @@ linkTitle: "API Reference"
 description: "Complete API reference for Console Managed Wallet API endpoints"
 ---
 
-Complete reference for all Console API endpoints.
+Complete reference for all Console Managed Wallet API endpoints.
+
+Base URL: `https://console-api.akash.network`
 
 ---
 
 ## Authentication
 
-Every request must include the `x-api-key` header. Create and manage keys in [Console](https://console.akash.network) from your profile menu -> API Keys.
-
-Example HTTP request:
+Every request must include the `x-api-key` header. Create and manage keys in [Console](https://console.akash.network) under Settings → API Keys.
 
 ```http
 GET /v1/deployments HTTP/1.1
@@ -26,8 +26,20 @@ x-api-key: YOUR_API_KEY
 Authentication errors return `401 Unauthorized`:
 
 ```json
-{ "error": "Unauthorized", "message": "Missing or invalid API key" }
+{ "error": "Unauthorized", "message": "Invalid API key" }
 ```
+
+---
+
+## Response envelope
+
+Every JSON response is wrapped in a top-level `data` field, for example:
+
+```json
+{ "data": { "...": "..." } }
+```
+
+For list endpoints, `data` contains both the array and a `pagination` object. All examples below show the full response body.
 
 ---
 
@@ -35,22 +47,18 @@ Authentication errors return `401 Unauthorized`:
 
 The API uses standard HTTP status codes. All error responses share the same JSON shape.
 
-| HTTP Status | Code string | Description |
-|---|---|---|
-| 400 | BadRequest | The request body or query parameters are invalid. Check `message` for details. |
-| 401 | Unauthorized | `x-api-key` is missing, expired, or invalid. |
-| 404 | NotFound | The resource (`dseq`) does not exist or is not owned by the authenticated user. |
-| 409 | Conflict | Action conflicts with current resource state (for example, lease already exists). |
-| 429 | TooManyRequests | Request rate exceeded. Wait before retrying. |
-| 500 | InternalServerError | Unexpected server error. Retry with exponential backoff. |
+| HTTP Status | Code string         | Description                                                                     |
+| ----------- | ------------------- | ------------------------------------------------------------------------------- |
+| 400         | BadRequest          | The request body or query parameters are invalid. Check `message` for details.  |
+| 401         | Unauthorized        | `x-api-key` is missing, expired, or invalid.                                    |
+| 404         | NotFound            | The resource (`dseq`) does not exist or is not owned by the authenticated user. |
+| 429         | TooManyRequests     | Request rate exceeded. Wait before retrying.                                    |
+| 500         | InternalServerError | Unexpected server error. Retry with exponential backoff.                        |
 
 Error response schema:
 
 ```json
-{
-  "error": "string",
-  "message": "string"
-}
+{ "error": "string", "message": "string" }
 ```
 
 ---
@@ -59,12 +67,12 @@ Error response schema:
 
 Endpoints are prefixed with a version number (`/v1/` or `/v2/`). Versions are independent. Upgrading one endpoint version does not affect others.
 
-| Version | Status | Endpoints |
-|---|---|---|
-| v1 | Stable | Deployments, bids, leases, deposit |
-| v2 | Stable | Deployment settings |
+| Version | Status | Endpoints                          |
+| ------- | ------ | ---------------------------------- |
+| v1      | Stable | Deployments, bids, leases, deposit |
+| v2      | Stable | Deployment settings (auto top-up)  |
 
-Path-level versioning means you can adopt `/v2/deployment-settings` without changing existing `/v1/deployments` calls. Future breaking changes are introduced as a new version prefix, and prior versions remain available for a deprecation period announced in the changelog ([https://github.com/akash-network/console/releases](https://github.com/akash-network/console/releases)).
+Future breaking changes are introduced as a new version prefix, and prior versions remain available for a deprecation period announced in the changelog ([https://github.com/akash-network/console/releases](https://github.com/akash-network/console/releases)).
 
 ---
 
@@ -72,12 +80,12 @@ Path-level versioning means you can adopt `/v2/deployment-settings` without chan
 
 `GET /v1/deployments` uses offset-based pagination via `skip` and `limit`.
 
-| Parameter | Type | Default | Maximum | Description |
-|---|---|---|---|---|
-| skip | integer | 0 | - | Number of records to skip (offset) |
-| limit | integer | 10 | 100 | Maximum records to return per page |
+| Parameter | Type    | Default | Minimum | Description                        |
+| --------- | ------- | ------- | ------- | ---------------------------------- |
+| skip      | integer | 0       | 0       | Number of records to skip (offset) |
+| limit     | integer | 1000    | 1       | Maximum records to return per page |
 
-Fetching all deployments (JavaScript generator):
+The response includes a `pagination` object with `total`, `skip`, `limit`, and `hasMore` so you can drive a paging loop without guessing when to stop:
 
 ```javascript
 async function* getAllDeployments() {
@@ -86,32 +94,33 @@ async function* getAllDeployments() {
   while (true) {
     const res = await fetch(
       `https://console-api.akash.network/v1/deployments?skip=${skip}&limit=${limit}`,
-      { headers: { "x-api-key": process.env.AKASH_API_KEY } }
+      { headers: { "x-api-key": process.env.AKASH_API_KEY } },
     );
-    const page = await res.json();
-    yield* page;
-    if (page.length < limit) break;
+    const { data } = await res.json();
+    yield* data.deployments;
+    if (!data.pagination.hasMore) break;
     skip += limit;
   }
 }
 ```
 
 ---
+
 ## POST /v1/deployments
 
 Create a new deployment from an SDL manifest and fund its escrow.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| sdl | body | string | yes | Deployment manifest in SDL (YAML) format, as a JSON string |
-| deposit | body | string | no | Initial escrow deposit in USD, for example `"5.00"` |
+| Field        | Location | Type   | Required | Description                                                |
+| ------------ | -------- | ------ | -------- | ---------------------------------------------------------- |
+| x-api-key    | header   | string | yes      | Your API key                                               |
+| data.sdl     | body     | string | yes      | Deployment manifest in SDL (YAML) format, as a JSON string |
+| data.deposit | body     | number | yes      | Initial escrow deposit in USD, for example `5.5`           |
 
 ```bash
 curl -X POST https://console-api.akash.network/v1/deployments \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"sdl": "version: \"2.0\"\n..."}'
+  -d '{ "data": { "sdl": "version: \"2.0\"\n...", "deposit": 5.5 } }'
 ```
 
 ```javascript
@@ -121,19 +130,29 @@ const res = await fetch("https://console-api.akash.network/v1/deployments", {
     "x-api-key": process.env.AKASH_API_KEY,
     "Content-Type": "application/json",
   },
-  body: JSON.stringify({ sdl: sdlString }),
+  body: JSON.stringify({ data: { sdl: sdlString, deposit: 5.5 } }),
 });
-const { dseq } = await res.json();
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| dseq | string | Deployment sequence ID |
-| status | string | Deployment status |
-| createdAt | string | ISO-8601 creation time |
+Response `201 Created`:
+
+| Field                       | Type   | Description                                           |
+| --------------------------- | ------ | ----------------------------------------------------- |
+| data.dseq                   | string | Deployment sequence ID                                |
+| data.manifest               | string | Rendered manifest blob to send with `POST /v1/leases` |
+| data.signTx.code            | number | Cosmos tx code (0 = success)                          |
+| data.signTx.transactionHash | string | Broadcast transaction hash                            |
+| data.signTx.rawLog          | string | Raw chain log                                         |
 
 ```json
-{ "dseq": "1234567", "status": "active", "createdAt": "2024-01-15T10:30:00Z" }
+{
+  "data": {
+    "dseq": "1234567",
+    "manifest": "...",
+    "signTx": { "code": 0, "transactionHash": "ABCDEF...", "rawLog": "[...]" }
+  }
+}
 ```
 
 ---
@@ -142,10 +161,10 @@ const { dseq } = await res.json();
 
 List provider bids for a deployment. Poll until bids arrive.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| dseq | query | string | yes | Deployment sequence ID returned by create deployment |
+| Field     | Location | Type   | Required | Description                                          |
+| --------- | -------- | ------ | -------- | ---------------------------------------------------- |
+| x-api-key | header   | string | yes      | Your API key                                         |
+| dseq      | query    | string | yes      | Deployment sequence ID returned by create deployment |
 
 ```bash
 curl "https://console-api.akash.network/v1/bids?dseq=1234567" \
@@ -153,45 +172,84 @@ curl "https://console-api.akash.network/v1/bids?dseq=1234567" \
 ```
 
 ```javascript
-const res = await fetch(`https://console-api.akash.network/v1/bids?dseq=${dseq}`, {
-  headers: { "x-api-key": process.env.AKASH_API_KEY },
-});
-const bids = await res.json();
+const res = await fetch(
+  `https://console-api.akash.network/v1/bids?dseq=${dseq}`,
+  {
+    headers: { "x-api-key": process.env.AKASH_API_KEY },
+  },
+);
+const { data: bids } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| id | string | Bid ID |
-| provider | string | Provider address |
-| price | string | Bid price amount |
-| denom | string | Price denomination |
-| status | string | Bid status |
+Response `200 OK` (returns `{ "data": [] }` while bids are pending):
+
+| Field                      | Type   | Description                                      |
+| -------------------------- | ------ | ------------------------------------------------ |
+| data[].bid.id.owner        | string | Owner address                                    |
+| data[].bid.id.dseq         | string | Deployment sequence ID                           |
+| data[].bid.id.gseq         | number | Group sequence                                   |
+| data[].bid.id.oseq         | number | Order sequence                                   |
+| data[].bid.id.provider     | string | Provider address                                 |
+| data[].bid.id.bseq         | number | Bid sequence (chain height)                      |
+| data[].bid.state           | string | Bid state (e.g. `open`)                          |
+| data[].bid.price.denom     | string | Chain denom (e.g. `uact`)                        |
+| data[].bid.price.amount    | string | Chain amount in micro-units, per block           |
+| data[].bid.created_at      | string | Chain height at creation                         |
+| data[].bid.resources_offer | array  | Offered CPU / memory / storage / GPU / endpoints |
+| data[].escrow_account      | object | Provider's bid escrow account                    |
 
 ```json
-[
-  { "id": "bid_abc123", "provider": "akash1abc...xyz", "price": "0.50", "denom": "usd", "status": "open" }
-]
+{
+  "data": [
+    {
+      "bid": {
+        "id": {
+          "owner": "akash1...",
+          "dseq": "1234567",
+          "gseq": 1,
+          "oseq": 1,
+          "provider": "akash1...",
+          "bseq": 92
+        },
+        "state": "open",
+        "price": { "denom": "uact", "amount": "10000" },
+        "created_at": "92",
+        "resources_offer": [{ "resources": { "...": "..." }, "count": 1 }]
+      },
+      "escrow_account": { "...": "..." }
+    }
+  ]
+}
 ```
 
-> Note: This endpoint returns `[]` while bids are pending.
+> Note: there is no flat `bid.id` string — the bid is identified by the composite `{owner, dseq, gseq, oseq, provider, bseq}`. When creating a lease, copy `dseq`, `gseq`, `oseq`, and `provider` from this object.
 
 ---
 
 ## POST /v1/leases
 
-Accept a provider bid and activate the deployment lease.
+Accept one or more provider bids and ship the manifest in a single call.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| dseq | body | string | yes | Deployment sequence ID |
-| bidId | body | string | yes | Bid ID from `GET /v1/bids` |
+| Field             | Location | Type   | Required | Description                                      |
+| ----------------- | -------- | ------ | -------- | ------------------------------------------------ |
+| x-api-key         | header   | string | yes      | Your API key                                     |
+| manifest          | body     | string | yes      | Manifest blob returned by `POST /v1/deployments` |
+| leases            | body     | array  | yes      | One entry per bid to accept                      |
+| leases[].dseq     | body     | string | yes      | Deployment sequence ID                           |
+| leases[].gseq     | body     | number | yes      | Group sequence (from `bid.id.gseq`)              |
+| leases[].oseq     | body     | number | yes      | Order sequence (from `bid.id.oseq`)              |
+| leases[].provider | body     | string | yes      | Provider address (from `bid.id.provider`)        |
 
 ```bash
 curl -X POST https://console-api.akash.network/v1/leases \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"dseq": "1234567", "bidId": "bid_abc123"}'
+  -d '{
+    "manifest": "<MANIFEST>",
+    "leases": [
+      { "dseq": "1234567", "gseq": 1, "oseq": 1, "provider": "akash1provider..." }
+    ]
+  }'
 ```
 
 ```javascript
@@ -201,62 +259,58 @@ const res = await fetch("https://console-api.akash.network/v1/leases", {
     "x-api-key": process.env.AKASH_API_KEY,
     "Content-Type": "application/json",
   },
-  body: JSON.stringify({ dseq, bidId }),
+  body: JSON.stringify({
+    manifest,
+    leases: [
+      {
+        dseq: chosen.dseq,
+        gseq: chosen.gseq,
+        oseq: chosen.oseq,
+        provider: chosen.provider,
+      },
+    ],
+  }),
 });
-const lease = await res.json();
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| leaseId | string | Lease ID |
-| dseq | string | Deployment sequence ID |
-| provider | string | Selected provider |
-| status | string | Lease status |
-
-```json
-{ "leaseId": "lease_xyz789", "dseq": "1234567", "provider": "akash1abc...xyz", "status": "active" }
-```
+Response `200 OK` is the same shape as `GET /v1/deployments/{dseq}` — see below.
 
 ---
 
 ## POST /v1/deposit-deployment
 
-Add funds to a deployment's escrow to extend its runtime.
+Add USD funds to a deployment's escrow to extend its runtime.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| dseq | body | string | yes | Deployment sequence ID |
-| amount | body | string | yes | Deposit amount in USD, for example `"10.00"` |
+| Field        | Location | Type   | Required | Description                             |
+| ------------ | -------- | ------ | -------- | --------------------------------------- |
+| x-api-key    | header   | string | yes      | Your API key                            |
+| data.dseq    | body     | string | yes      | Deployment sequence ID                  |
+| data.deposit | body     | number | yes      | Deposit amount in USD, for example `10` |
 
 ```bash
 curl -X POST https://console-api.akash.network/v1/deposit-deployment \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"dseq": "1234567", "amount": "10.00"}'
+  -d '{ "data": { "dseq": "1234567", "deposit": 10 } }'
 ```
 
 ```javascript
-const res = await fetch("https://console-api.akash.network/v1/deposit-deployment", {
-  method: "POST",
-  headers: {
-    "x-api-key": process.env.AKASH_API_KEY,
-    "Content-Type": "application/json",
+const res = await fetch(
+  "https://console-api.akash.network/v1/deposit-deployment",
+  {
+    method: "POST",
+    headers: {
+      "x-api-key": process.env.AKASH_API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ data: { dseq, deposit: 10 } }),
   },
-  body: JSON.stringify({ dseq, amount: "10.00" }),
-});
-const data = await res.json();
+);
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| dseq | string | Deployment sequence ID |
-| depositedAmount | string | Amount deposited |
-| newBalance | string | New escrow balance |
-
-```json
-{ "dseq": "1234567", "depositedAmount": "10.00", "newBalance": "14.73" }
-```
+Response `200 OK`: full deployment object after the top-up; see `GET /v1/deployments/{dseq}` below. The new escrow balance is in `data.escrow_account.state.funds[].amount` (raw chain micro-units).
 
 ---
 
@@ -264,11 +318,11 @@ const data = await res.json();
 
 List all deployments for the authenticated user, with pagination.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| skip | query | integer | no | Offset. Default `0` |
-| limit | query | integer | no | Max records. Default `10`, max `100` |
+| Field     | Location | Type    | Required | Description                 |
+| --------- | -------- | ------- | -------- | --------------------------- |
+| x-api-key | header   | string  | yes      | Your API key                |
+| skip      | query    | integer | no       | Offset. Default `0`         |
+| limit     | query    | integer | no       | Max records. Default `1000` |
 
 ```bash
 curl "https://console-api.akash.network/v1/deployments?skip=0&limit=10" \
@@ -276,24 +330,38 @@ curl "https://console-api.akash.network/v1/deployments?skip=0&limit=10" \
 ```
 
 ```javascript
-const res = await fetch("https://console-api.akash.network/v1/deployments?skip=0&limit=10", {
-  headers: { "x-api-key": process.env.AKASH_API_KEY },
-});
-const deployments = await res.json();
+const res = await fetch(
+  "https://console-api.akash.network/v1/deployments?skip=0&limit=10",
+  {
+    headers: { "x-api-key": process.env.AKASH_API_KEY },
+  },
+);
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| dseq | string | Deployment sequence ID |
-| status | string | Deployment status |
-| createdAt | string | ISO-8601 creation time |
-| balance | string | Current escrow balance in USD |
+Response `200 OK`:
+
+| Field                   | Type    | Description                                                                                   |
+| ----------------------- | ------- | --------------------------------------------------------------------------------------------- |
+| data.deployments[]      | array   | One entry per deployment, same shape as `GET /v1/deployments/{dseq}` minus per-lease `status` |
+| data.pagination.total   | number  | Total deployments for the user                                                                |
+| data.pagination.skip    | number  | Skip value used                                                                               |
+| data.pagination.limit   | number  | Limit value used                                                                              |
+| data.pagination.hasMore | boolean | True when more pages are available                                                            |
 
 ```json
-[
-  { "dseq": "1234567", "status": "active", "createdAt": "2024-01-15T10:30:00Z", "balance": "9.23" },
-  { "dseq": "1234568", "status": "closed", "createdAt": "2024-01-10T08:00:00Z", "balance": "0.00" }
-]
+{
+  "data": {
+    "deployments": [
+      {
+        "deployment": { "...": "..." },
+        "leases": [],
+        "escrow_account": { "...": "..." }
+      }
+    ],
+    "pagination": { "total": 23, "skip": 0, "limit": 10, "hasMore": true }
+  }
+}
 ```
 
 ---
@@ -302,10 +370,10 @@ const deployments = await res.json();
 
 Retrieve full details for a single deployment by its sequence ID.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| dseq | path | string | yes | Deployment sequence ID |
+| Field     | Location | Type   | Required | Description            |
+| --------- | -------- | ------ | -------- | ---------------------- |
+| x-api-key | header   | string | yes      | Your API key           |
+| dseq      | path     | string | yes      | Deployment sequence ID |
 
 ```bash
 curl "https://console-api.akash.network/v1/deployments/1234567" \
@@ -313,30 +381,65 @@ curl "https://console-api.akash.network/v1/deployments/1234567" \
 ```
 
 ```javascript
-const res = await fetch(`https://console-api.akash.network/v1/deployments/${dseq}`, {
-  headers: { "x-api-key": process.env.AKASH_API_KEY },
-});
-const deployment = await res.json();
+const res = await fetch(
+  `https://console-api.akash.network/v1/deployments/${dseq}`,
+  {
+    headers: { "x-api-key": process.env.AKASH_API_KEY },
+  },
+);
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| dseq | string | Deployment sequence ID |
-| status | string | Deployment status |
-| sdl | string | SDL used for deployment |
-| provider | string | Provider address |
-| balance | string | Current balance |
-| leaseId | string | Active lease ID |
+Response `200 OK`:
+
+| Field                      | Type   | Description                                                                                |
+| -------------------------- | ------ | ------------------------------------------------------------------------------------------ |
+| data.deployment.id.owner   | string | Owner address                                                                              |
+| data.deployment.id.dseq    | string | Deployment sequence ID                                                                     |
+| data.deployment.state      | string | Deployment state (`active`, `closed`)                                                      |
+| data.deployment.hash       | string | Manifest hash                                                                              |
+| data.deployment.created_at | string | Chain height at creation                                                                   |
+| data.leases[]              | array  | Active leases (composite id + `state`, `price`, `created_at`, `closed_on`, `status`)       |
+| data.escrow_account        | object | Deployment escrow account with `funds[]`, `deposits[]`, `transferred[]` (raw chain denoms) |
 
 ```json
 {
-  "dseq": "1234567",
-  "status": "active",
-  "sdl": "version: \"2.0\"...",
-  "provider": "akash1abc...xyz",
-  "balance": "9.23",
-  "createdAt": "2024-01-15T10:30:00Z",
-  "leaseId": "lease_xyz789"
+  "data": {
+    "deployment": {
+      "id": { "owner": "akash1ownerxxx...", "dseq": "1234567" },
+      "state": "active",
+      "hash": "...",
+      "created_at": "92"
+    },
+    "leases": [
+      {
+        "id": {
+          "owner": "akash1ownerxxx...",
+          "dseq": "1234567",
+          "gseq": 1,
+          "oseq": 1,
+          "provider": "akash1providerxxx...",
+          "bseq": 92
+        },
+        "state": "active",
+        "price": { "denom": "uact", "amount": "10000" },
+        "created_at": "92",
+        "closed_on": "",
+        "status": { "forwarded_ports": {}, "ips": {}, "services": {} }
+      }
+    ],
+    "escrow_account": {
+      "id": { "scope": "deployment", "xid": "..." },
+      "state": {
+        "owner": "akash1ownerxxx...",
+        "state": "open",
+        "transferred": [],
+        "settled_at": "92",
+        "funds": [{ "denom": "uact", "amount": "5500000" }],
+        "deposits": []
+      }
+    }
+  }
 }
 ```
 
@@ -346,51 +449,46 @@ const deployment = await res.json();
 
 Update an active deployment with a revised SDL.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| dseq | path | string | yes | Deployment sequence ID |
-| sdl | body | string | yes | Updated SDL in YAML format, passed as a JSON string |
+| Field     | Location | Type   | Required | Description                                         |
+| --------- | -------- | ------ | -------- | --------------------------------------------------- |
+| x-api-key | header   | string | yes      | Your API key                                        |
+| dseq      | path     | string | yes      | Deployment sequence ID                              |
+| data.sdl  | body     | string | yes      | Updated SDL in YAML format, passed as a JSON string |
 
 ```bash
 curl -X PUT "https://console-api.akash.network/v1/deployments/1234567" \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"sdl": "version: \"2.0\"\n..."}'
+  -d '{ "data": { "sdl": "version: \"2.0\"\n..." } }'
 ```
 
 ```javascript
-const res = await fetch(`https://console-api.akash.network/v1/deployments/${dseq}`, {
-  method: "PUT",
-  headers: {
-    "x-api-key": process.env.AKASH_API_KEY,
-    "Content-Type": "application/json",
+const res = await fetch(
+  `https://console-api.akash.network/v1/deployments/${dseq}`,
+  {
+    method: "PUT",
+    headers: {
+      "x-api-key": process.env.AKASH_API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ data: { sdl: updatedSdl } }),
   },
-  body: JSON.stringify({ sdl: updatedSdl }),
-});
-const updated = await res.json();
+);
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| dseq | string | Deployment sequence ID |
-| status | string | Deployment status |
-| updatedAt | string | ISO-8601 update time |
-
-```json
-{ "dseq": "1234567", "status": "active", "updatedAt": "2024-01-16T09:00:00Z" }
-```
+Response `200 OK`: full deployment object — same shape as `GET /v1/deployments/{dseq}`.
 
 ---
 
 ## DELETE /v1/deployments/{dseq}
 
-Close a deployment and return remaining escrow funds to your account.
+Close a deployment. Remaining escrow is returned asynchronously by the chain to your Console balance.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| dseq | path | string | yes | Deployment sequence ID to close |
+| Field     | Location | Type   | Required | Description                     |
+| --------- | -------- | ------ | -------- | ------------------------------- |
+| x-api-key | header   | string | yes      | Your API key                    |
+| dseq      | path     | string | yes      | Deployment sequence ID to close |
 
 ```bash
 curl -X DELETE "https://console-api.akash.network/v1/deployments/1234567" \
@@ -398,35 +496,33 @@ curl -X DELETE "https://console-api.akash.network/v1/deployments/1234567" \
 ```
 
 ```javascript
-const res = await fetch(`https://console-api.akash.network/v1/deployments/${dseq}`, {
-  method: "DELETE",
-  headers: { "x-api-key": process.env.AKASH_API_KEY },
-});
-const closed = await res.json();
+const res = await fetch(
+  `https://console-api.akash.network/v1/deployments/${dseq}`,
+  {
+    method: "DELETE",
+    headers: { "x-api-key": process.env.AKASH_API_KEY },
+  },
+);
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| dseq | string | Deployment sequence ID |
-| status | string | Deployment status |
-| refundedAmount | string | Refunded escrow amount |
-| closedAt | string | ISO-8601 close time |
+Response `200 OK`:
 
 ```json
-{ "dseq": "1234567", "status": "closed", "refundedAmount": "4.50", "closedAt": "2024-01-16T12:00:00Z" }
+{ "data": { "success": true } }
 ```
 
 ---
 
 ## GET /v2/deployment-settings/{dseq}
 
-Get auto top-up and other settings for a specific deployment.
+Get auto top-up settings for a specific deployment. Settings are auto-created on first read.
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| dseq | path | string | yes | Deployment sequence number |
-| userId | query | string | no | Defaults to authenticated user |
+| Field     | Location | Type   | Required | Description                    |
+| --------- | -------- | ------ | -------- | ------------------------------ |
+| x-api-key | header   | string | yes      | Your API key                   |
+| dseq      | path     | string | yes      | Deployment sequence number     |
+| userId    | query    | string | no       | Defaults to authenticated user |
 
 ```bash
 curl "https://console-api.akash.network/v2/deployment-settings/1234567" \
@@ -434,90 +530,123 @@ curl "https://console-api.akash.network/v2/deployment-settings/1234567" \
 ```
 
 ```javascript
-const res = await fetch(`https://console-api.akash.network/v2/deployment-settings/${dseq}`, {
-  headers: { "x-api-key": process.env.AKASH_API_KEY },
-});
-const settings = await res.json();
+const res = await fetch(
+  `https://console-api.akash.network/v2/deployment-settings/${dseq}`,
+  {
+    headers: { "x-api-key": process.env.AKASH_API_KEY },
+  },
+);
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| dseq | string | Deployment sequence number |
-| autoTopUp | boolean | Auto top-up enabled state |
-| topUpThreshold | string | Threshold in USD |
-| topUpAmount | string | Top-up amount in USD |
+Response `200 OK`:
+
+| Field                     | Type          | Description                             |
+| ------------------------- | ------------- | --------------------------------------- |
+| data.id                   | string (uuid) | Setting record id                       |
+| data.userId               | string        | Owning user id                          |
+| data.dseq                 | string        | Deployment sequence number              |
+| data.autoTopUpEnabled     | boolean       | Whether auto top-up is enabled          |
+| data.estimatedTopUpAmount | number        | Estimated top-up amount per cycle (USD) |
+| data.topUpFrequencyMs     | number        | Top-up cadence in milliseconds          |
+| data.createdAt            | string        | ISO-8601 creation time                  |
+| data.updatedAt            | string        | ISO-8601 last update time               |
 
 ```json
-{ "dseq": "1234567", "autoTopUp": true, "topUpThreshold": "2.00", "topUpAmount": "5.00" }
+{
+  "data": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "userId": "00000000-0000-0000-0000-000000000000",
+    "dseq": "1234567",
+    "autoTopUpEnabled": true,
+    "estimatedTopUpAmount": 5,
+    "topUpFrequencyMs": 86400000,
+    "createdAt": "2024-01-15T10:30:00Z",
+    "updatedAt": "2024-01-15T10:30:00Z"
+  }
+}
 ```
 
 ---
 
 ## POST /v2/deployment-settings
 
-Create or update auto top-up settings for a deployment.
+Create deployment settings (typically used to enable auto top-up when the settings row does not yet exist).
 
-| Field | Location | Type | Required | Description |
-|---|---|---|---|---|
-| x-api-key | header | string | yes | Your API key |
-| dseq | body | string | yes | Deployment sequence number |
-| autoTopUp | body | boolean | yes | Enable or disable automatic top-up |
-| topUpThreshold | body | string | conditional | Required when `autoTopUp` is `true` |
-| topUpAmount | body | string | conditional | Required when `autoTopUp` is `true` |
+| Field                 | Location | Type          | Required | Description                        |
+| --------------------- | -------- | ------------- | -------- | ---------------------------------- |
+| x-api-key             | header   | string        | yes      | Your API key                       |
+| data.dseq             | body     | string        | yes      | Deployment sequence number         |
+| data.autoTopUpEnabled | body     | boolean       | yes      | Enable or disable automatic top-up |
+| data.userId           | body     | string (uuid) | no       | Defaults to authenticated user     |
 
 ```bash
 curl -X POST https://console-api.akash.network/v2/deployment-settings \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "dseq": "1234567",
-    "autoTopUp": true,
-    "topUpThreshold": "2.00",
-    "topUpAmount": "5.00"
-  }'
+  -d '{ "data": { "dseq": "1234567", "autoTopUpEnabled": true } }'
 ```
 
 ```javascript
-const res = await fetch("https://console-api.akash.network/v2/deployment-settings", {
-  method: "POST",
-  headers: {
-    "x-api-key": process.env.AKASH_API_KEY,
-    "Content-Type": "application/json",
+const res = await fetch(
+  "https://console-api.akash.network/v2/deployment-settings",
+  {
+    method: "POST",
+    headers: {
+      "x-api-key": process.env.AKASH_API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ data: { dseq, autoTopUpEnabled: true } }),
   },
-  body: JSON.stringify({
-    dseq,
-    autoTopUp: true,
-    topUpThreshold: "2.00",
-    topUpAmount: "5.00",
-  }),
-});
-const created = await res.json();
+);
+const { data } = await res.json();
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| dseq | string | Deployment sequence number |
-| autoTopUp | boolean | Auto top-up state |
-| topUpThreshold | string | Threshold in USD |
-| topUpAmount | string | Top-up amount in USD |
-| createdAt | string | ISO-8601 creation time |
+Response `201 Created`: same shape as `GET /v2/deployment-settings/{dseq}`.
 
-```json
-{
-  "dseq": "1234567",
-  "autoTopUp": true,
-  "topUpThreshold": "2.00",
-  "topUpAmount": "5.00",
-  "createdAt": "2024-01-15T10:30:00Z"
-}
+---
+
+## PATCH /v2/deployment-settings/{dseq}
+
+Update an existing settings row.
+
+| Field                 | Location | Type          | Required | Description                        |
+| --------------------- | -------- | ------------- | -------- | ---------------------------------- |
+| x-api-key             | header   | string        | yes      | Your API key                       |
+| dseq                  | path     | string        | yes      | Deployment sequence number         |
+| userId                | query    | string (uuid) | no       | Defaults to authenticated user     |
+| data.autoTopUpEnabled | body     | boolean       | yes      | Enable or disable automatic top-up |
+
+```bash
+curl -X PATCH https://console-api.akash.network/v2/deployment-settings/1234567 \
+  -H "x-api-key: $AKASH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "data": { "autoTopUpEnabled": false } }'
 ```
+
+```javascript
+const res = await fetch(
+  `https://console-api.akash.network/v2/deployment-settings/${dseq}`,
+  {
+    method: "PATCH",
+    headers: {
+      "x-api-key": process.env.AKASH_API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ data: { autoTopUpEnabled: false } }),
+  },
+);
+const { data } = await res.json();
+```
+
+Response `200 OK`: same shape as `GET /v2/deployment-settings/{dseq}`.
 
 ---
 
 ## See Also
 
 - **[Getting Started](/docs/api-documentation/console-api/getting-started)** - Full workflow with examples
-- **[SDL Reference](https://docs.akash.network/docs/getting-started/stack-definition-language/)** - SDL syntax and options
-- **[Akash CLI](https://docs.akash.network/docs/deployments/akash-cli/installation/)** - Wallet-based deployments
+- **[Quickstart](/docs/api-documentation/console-api/quickstart)** - End-to-end deployment in five API calls
+- **[SDL Reference](/docs/developers/deployment/akash-sdl)** - SDL syntax and options
 - **[Console](https://console.akash.network)** - Visual interface for managing deployments
 - **[GitHub: akash-network/console](https://github.com/akash-network/console)** - Source and issues

--- a/src/content/Docs/api-documentation/console-api/getting-started/index.md
+++ b/src/content/Docs/api-documentation/console-api/getting-started/index.md
@@ -39,14 +39,30 @@ curl https://console-api.akash.network/v1/deployments \
 If the key is missing or invalid, the API returns `401 Unauthorized`:
 
 ```json
-{ "error": "Unauthorized", "message": "Missing or invalid API key" }
+{ "error": "Unauthorized", "message": "Invalid API key" }
 ```
 
 Security practices:
 
 - Store the key in an environment variable (`AKASH_API_KEY`), never in source code.
-- Rotate keys in Console under Settings -> API Keys to keep your workflows safe in case of key compromise.
+- Rotate keys in Console under Settings → API Keys to keep your workflows safe in case of key compromise.
 - Keys grant full access to your Console account, so treat them like passwords.
+
+### Response envelope
+
+Every JSON response from the Console API is wrapped in a top-level `data` field, for example:
+
+```json
+{ "data": { "dseq": "1234567", "manifest": "...", "signTx": { ... } } }
+```
+
+All examples in this guide show the full response body — extract the value you need from `response.data`.
+
+### Money fields
+
+The Managed Wallet bills your Console account in **USD** (credit card). The `deposit` field on `POST /v1/deployments` and `POST /v1/deposit-deployment` is a number in dollars (for example `5.5` = $5.50).
+
+The blockchain itself works in raw on-chain denoms (`uact`, `uusdc`, …). Wherever you see `price.denom` / `price.amount` in a bid response or an `escrow_account.state.funds` entry, those are raw chain values in micro-units (1 ACT = 1 000 000 uact). The SDL `pricing` block also uses chain denoms — the managed wallet handles the USD ↔ chain conversion for you.
 
 ---
 
@@ -54,7 +70,7 @@ Security practices:
 
 ### 1. Create Deployment
 
-POST your SDL to create a deployment. The API returns a `dseq` (deployment sequence number) that identifies the deployment in all subsequent calls.
+POST your SDL plus an initial USD `deposit` to create a deployment. The API returns a `dseq` (deployment sequence number) that identifies the deployment in all subsequent calls. The response also returns the broadcast transaction hash for the on-chain `MsgCreateDeployment`.
 
 cURL:
 
@@ -62,7 +78,12 @@ cURL:
 curl -X POST https://console-api.akash.network/v1/deployments \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"sdl": "<YOUR_SDL_YAML_AS_STRING>"}'
+  -d '{
+    "data": {
+      "sdl": "<YOUR_SDL_YAML_AS_STRING>",
+      "deposit": 5.5
+    }
+  }'
 ```
 
 JavaScript (fetch):
@@ -74,18 +95,25 @@ const res = await fetch("https://console-api.akash.network/v1/deployments", {
     "x-api-key": process.env.AKASH_API_KEY,
     "Content-Type": "application/json",
   },
-  body: JSON.stringify({ sdl: YOUR_SDL_STRING }),
+  body: JSON.stringify({ data: { sdl: YOUR_SDL_STRING, deposit: 5.5 } }),
 });
-const { dseq } = await res.json();
+const { data } = await res.json();
+const dseq = data.dseq;
 ```
 
-Response:
+Response (`201 Created`):
 
 ```json
 {
-  "dseq": "1234567",
-  "status": "active",
-  "createdAt": "2024-01-15T10:30:00Z"
+  "data": {
+    "dseq": "1234567",
+    "manifest": "<computed manifest hash + manifest blob>",
+    "signTx": {
+      "code": 0,
+      "transactionHash": "ABCDEF...",
+      "rawLog": "[...]"
+    }
+  }
 }
 ```
 
@@ -93,7 +121,7 @@ Response:
 
 ### 2. Wait for and Fetch Bids
 
-List bids for your deployment. Bids typically arrive within 30-60 seconds.
+List bids for your deployment. Bids typically arrive within 30–60 seconds. The response is wrapped in `data` and each bid is identified by a **composite id** (`owner`/`dseq`/`gseq`/`oseq`/`provider`/`bseq`), not a single opaque string.
 
 cURL:
 
@@ -107,23 +135,55 @@ JavaScript (fetch):
 ```javascript
 const res = await fetch(
   `https://console-api.akash.network/v1/bids?dseq=${dseq}`,
-  { headers: { "x-api-key": process.env.AKASH_API_KEY } }
+  { headers: { "x-api-key": process.env.AKASH_API_KEY } },
 );
-const bids = await res.json();
+const { data: bids } = await res.json();
 ```
 
 Response:
 
 ```json
-[
-  {
-    "id": "bid_abc123",
-    "provider": "akash1abc...xyz",
-    "price": "0.50",
-    "denom": "usd",
-    "status": "open"
-  }
-]
+{
+  "data": [
+    {
+      "bid": {
+        "id": {
+          "owner": "akash1ownerxxx...",
+          "dseq": "1234567",
+          "gseq": 1,
+          "oseq": 1,
+          "provider": "akash1providerxxx...",
+          "bseq": 92
+        },
+        "state": "open",
+        "price": { "denom": "uact", "amount": "10000" },
+        "created_at": "92",
+        "resources_offer": [
+          {
+            "resources": {
+              "cpu": { "units": { "val": "500" } },
+              "memory": { "quantity": { "val": "536870912" } },
+              "storage": [],
+              "endpoints": []
+            },
+            "count": 1
+          }
+        ]
+      },
+      "escrow_account": {
+        "id": { "scope": "bid", "xid": "..." },
+        "state": {
+          "owner": "akash1providerxxx...",
+          "state": "open",
+          "transferred": [],
+          "settled_at": "...",
+          "funds": [],
+          "deposits": []
+        }
+      }
+    }
+  ]
+}
 ```
 
 Polling example:
@@ -133,10 +193,10 @@ async function waitForBids(dseq, { pollMs = 3000, maxAttempts = 20 } = {}) {
   for (let i = 0; i < maxAttempts; i++) {
     const res = await fetch(
       `https://console-api.akash.network/v1/bids?dseq=${dseq}`,
-      { headers: { "x-api-key": process.env.AKASH_API_KEY } }
+      { headers: { "x-api-key": process.env.AKASH_API_KEY } },
     );
-    const bids = await res.json();
-    if (bids.length > 0) return bids;
+    const { data } = await res.json();
+    if (data.length > 0) return data;
     await new Promise((r) => setTimeout(r, pollMs));
   }
   throw new Error("No bids received within timeout");
@@ -147,7 +207,9 @@ async function waitForBids(dseq, { pollMs = 3000, maxAttempts = 20 } = {}) {
 
 ### 3. Create Lease
 
-Accept a bid to activate the deployment lease.
+Accept one or more bids to activate the deployment lease(s) and send the manifest to the chosen provider(s) in a single call.
+
+Pick the bid(s) you want, then build the `leases[]` array from the bid id (omitting `owner` and `bseq`). The `manifest` field is the rendered manifest produced by the SDL — you can re-use the manifest hash returned by `POST /v1/deployments` if you cached it.
 
 cURL:
 
@@ -155,31 +217,79 @@ cURL:
 curl -X POST https://console-api.akash.network/v1/leases \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"dseq": "1234567", "bidId": "bid_abc123"}'
+  -d '{
+    "manifest": "<MANIFEST_FROM_CREATE_DEPLOYMENT>",
+    "leases": [
+      { "dseq": "1234567", "gseq": 1, "oseq": 1, "provider": "akash1providerxxx..." }
+    ]
+  }'
 ```
 
 JavaScript (fetch):
 
 ```javascript
+const chosen = bids[0].bid.id;
 const res = await fetch("https://console-api.akash.network/v1/leases", {
   method: "POST",
   headers: {
     "x-api-key": process.env.AKASH_API_KEY,
     "Content-Type": "application/json",
   },
-  body: JSON.stringify({ dseq, bidId }),
+  body: JSON.stringify({
+    manifest,
+    leases: [
+      {
+        dseq: chosen.dseq,
+        gseq: chosen.gseq,
+        oseq: chosen.oseq,
+        provider: chosen.provider,
+      },
+    ],
+  }),
 });
-const lease = await res.json();
+const { data } = await res.json();
 ```
 
-Response:
+Response (`200 OK`) is the same shape as `GET /v1/deployments/{dseq}` — the full deployment object including its now-active lease(s):
 
 ```json
 {
-  "leaseId": "lease_xyz789",
-  "dseq": "1234567",
-  "provider": "akash1abc...xyz",
-  "status": "active"
+  "data": {
+    "deployment": {
+      "id": { "owner": "akash1ownerxxx...", "dseq": "1234567" },
+      "state": "active",
+      "hash": "...",
+      "created_at": "92"
+    },
+    "leases": [
+      {
+        "id": {
+          "owner": "akash1ownerxxx...",
+          "dseq": "1234567",
+          "gseq": 1,
+          "oseq": 1,
+          "provider": "akash1providerxxx...",
+          "bseq": 92
+        },
+        "state": "active",
+        "price": { "denom": "uact", "amount": "10000" },
+        "created_at": "92",
+        "closed_on": "",
+        "status": null
+      }
+    ],
+    "escrow_account": {
+      "id": { "scope": "deployment", "xid": "..." },
+      "state": {
+        "owner": "akash1ownerxxx...",
+        "state": "open",
+        "transferred": [],
+        "settled_at": "...",
+        "funds": [{ "denom": "uact", "amount": "5500000" }],
+        "deposits": []
+      }
+    }
+  }
 }
 ```
 
@@ -187,7 +297,7 @@ Response:
 
 ### 4. Add Deposit to Deployment
 
-Add funds to extend deployment runtime.
+Add USD funds to extend deployment runtime.
 
 cURL:
 
@@ -195,30 +305,35 @@ cURL:
 curl -X POST https://console-api.akash.network/v1/deposit-deployment \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"dseq": "1234567", "amount": "10.00"}'
+  -d '{ "data": { "dseq": "1234567", "deposit": 10 } }'
 ```
 
 JavaScript (fetch):
 
 ```javascript
-const res = await fetch("https://console-api.akash.network/v1/deposit-deployment", {
-  method: "POST",
-  headers: {
-    "x-api-key": process.env.AKASH_API_KEY,
-    "Content-Type": "application/json",
+const res = await fetch(
+  "https://console-api.akash.network/v1/deposit-deployment",
+  {
+    method: "POST",
+    headers: {
+      "x-api-key": process.env.AKASH_API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ data: { dseq, deposit: 10 } }),
   },
-  body: JSON.stringify({ dseq, amount: "10.00" }),
-});
-const depositResult = await res.json();
+);
+const { data } = await res.json();
 ```
 
-Response:
+Response (`200 OK`): the full deployment object after the top-up; the new balance is visible under `data.escrow_account.state.funds[].amount` (raw chain micro-units).
 
 ```json
 {
-  "dseq": "1234567",
-  "depositedAmount": "10.00",
-  "newBalance": "14.73"
+  "data": {
+    "deployment": { "...": "..." },
+    "leases": [],
+    "escrow_account": { "...": "..." }
+  }
 }
 ```
 
@@ -238,23 +353,23 @@ curl -X DELETE "https://console-api.akash.network/v1/deployments/1234567" \
 JavaScript (fetch):
 
 ```javascript
-const res = await fetch(`https://console-api.akash.network/v1/deployments/${dseq}`, {
-  method: "DELETE",
-  headers: { "x-api-key": process.env.AKASH_API_KEY },
-});
-const closeResult = await res.json();
+const res = await fetch(
+  `https://console-api.akash.network/v1/deployments/${dseq}`,
+  {
+    method: "DELETE",
+    headers: { "x-api-key": process.env.AKASH_API_KEY },
+  },
+);
+const { data } = await res.json();
 ```
 
-Response:
+Response (`200 OK`):
 
 ```json
-{
-  "dseq": "1234567",
-  "status": "closed",
-  "refundedAmount": "4.50",
-  "closedAt": "2024-01-16T12:00:00Z"
-}
+{ "data": { "success": true } }
 ```
+
+Any unspent escrow is returned to your Console balance asynchronously by the chain — call `GET /v1/deployments/{dseq}` afterward to inspect the final state, or check the [Console](https://console.akash.network) UI for the credited amount.
 
 ---
 
@@ -320,45 +435,49 @@ async function apiRequest(path, options = {}) {
 
 async function waitForBids(dseq, { pollMs = 3000, maxAttempts = 20 } = {}) {
   for (let i = 0; i < maxAttempts; i++) {
-    const response = await apiRequest(`/v1/bids?dseq=${dseq}`, {
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
-    });
-
-    // Current API shape returns bids under response.data.
-    if (response.data?.length > 0) return response.data;
+    const { data } = await apiRequest(`/v1/bids?dseq=${dseq}`);
+    if (data.length > 0) return data;
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
   throw new Error("No bids received within timeout");
 }
 
 async function main() {
-  const created = await apiRequest("/v1/deployments", {
+  const create = await apiRequest("/v1/deployments", {
     method: "POST",
-    body: JSON.stringify({ sdl: SDL }),
+    body: JSON.stringify({ data: { sdl: SDL, deposit: 5.5 } }),
   });
-  const dseq = created.dseq || created.data?.dseq;
-  if (!dseq) throw new Error("Missing dseq in create deployment response");
+  const { dseq, manifest } = create.data;
 
   const bids = await waitForBids(dseq);
-  const firstBid = bids[0];
-  const bidId = firstBid?.id || firstBid?.bid?.id;
-  if (!bidId) throw new Error("Missing bid identifier in bids response");
+  const chosenId = bids[0].bid.id;
 
   await apiRequest("/v1/leases", {
     method: "POST",
-    body: JSON.stringify({ dseq, bidId }),
+    body: JSON.stringify({
+      manifest,
+      leases: [
+        {
+          dseq: chosenId.dseq,
+          gseq: chosenId.gseq,
+          oseq: chosenId.oseq,
+          provider: chosenId.provider,
+        },
+      ],
+    }),
   });
 
   await apiRequest("/v1/deposit-deployment", {
     method: "POST",
-    body: JSON.stringify({ dseq, amount: "10.00" }),
+    body: JSON.stringify({ data: { dseq, deposit: 10 } }),
   });
 
-  const status = await apiRequest(`/v1/deployments/${dseq}`, { method: "GET" });
+  const status = await apiRequest(`/v1/deployments/${dseq}`);
   console.log("Deployment status:", status);
 
-  const closed = await apiRequest(`/v1/deployments/${dseq}`, { method: "DELETE" });
+  const closed = await apiRequest(`/v1/deployments/${dseq}`, {
+    method: "DELETE",
+  });
   console.log("Closed deployment:", closed);
 }
 
@@ -380,27 +499,26 @@ main().catch((err) => {
 - **Restrict key permissions** if possible
 
 ```typescript
-// **Good: Use environment variables
-const API_KEY = process.env.CONSOLE_API_KEY;
+// Good: use environment variables
+const API_KEY = process.env.AKASH_API_KEY;
 
-// **Bad: Hardcoded key
-const API_KEY = "akt_abc123...";
+// Bad: hardcoded key
+const API_KEY = "ac.sk.mainnet.xxx...";
 ```
 
 ### Error Handling
 
 Use HTTP status codes to determine recovery behavior.
 
-| Status | Meaning | Common cause |
-|---|---|---|
-| 200 OK | Request succeeded | - |
-| 201 Created | Resource created | POST to `/v1/deployments`, `/v1/leases`, `/v2/deployment-settings` |
-| 400 Bad Request | Invalid input | Malformed SDL, missing required field |
-| 401 Unauthorized | Auth failed | Missing or invalid `x-api-key` |
-| 404 Not Found | Resource not found | `dseq` does not exist or belongs to another user |
-| 409 Conflict | State conflict | Lease already exists for this deployment |
-| 429 Rate Limited | Rate limited | Polling interval too fast or burst of requests |
-| 500 Internal Server Error | Server error | Retry with exponential backoff |
+| Status                    | Meaning            | Common cause                                           |
+| ------------------------- | ------------------ | ------------------------------------------------------ |
+| 200 OK                    | Request succeeded  | -                                                      |
+| 201 Created               | Resource created   | `POST /v1/deployments`, `POST /v2/deployment-settings` |
+| 400 Bad Request           | Invalid input      | Malformed SDL, missing required field                  |
+| 401 Unauthorized          | Auth failed        | Missing or invalid `x-api-key`                         |
+| 404 Not Found             | Resource not found | `dseq` does not exist or belongs to another user       |
+| 429 Rate Limited          | Rate limited       | Polling interval too fast or burst of requests         |
+| 500 Internal Server Error | Server error       | Retry with exponential backoff                         |
 
 Error response shape:
 
@@ -413,21 +531,21 @@ Error response shape:
 
 ### Polling for Bids
 
-Poll every 3 seconds for 30-60 seconds, then back off or return a timeout error.
+Poll every 3 seconds for 30–60 seconds, then back off or return a timeout error.
 
 ---
 
 ## Managed Wallet vs SDK
 
-| Feature | Managed Wallet API | Akash SDK |
-|---------|-------------------|-----------|
-| **Wallet Management** | Managed by Console | You manage wallet |
-| **Authentication** | API Key | Private key/mnemonic |
-| **Payment** | Credit card (USD) | Crypto (AKT) |
-| **API Type** | REST API | Native blockchain |
-| **Language** | Any (HTTP) | Go, TypeScript |
-| **Setup** | API key only | Wallet + blockchain setup |
-| **Best For** | SaaS, web apps | Blockchain apps, CLI tools |
+| Feature               | Managed Wallet API | Akash SDK                  |
+| --------------------- | ------------------ | -------------------------- |
+| **Wallet Management** | Managed by Console | You manage wallet          |
+| **Authentication**    | API Key            | Private key/mnemonic       |
+| **Payment**           | Credit card (USD)  | Crypto (AKT)               |
+| **API Type**          | REST API           | Native blockchain          |
+| **Language**          | Any (HTTP)         | Go, TypeScript             |
+| **Setup**             | API key only       | Wallet + blockchain setup  |
+| **Best For**          | SaaS, web apps     | Blockchain apps, CLI tools |
 
 ## Limitations
 
@@ -441,8 +559,7 @@ Poll every 3 seconds for 30-60 seconds, then back off or return a timeout error.
 ## Resources
 
 - **[API Reference](/docs/api-documentation/console-api/api-reference)** - Complete endpoint documentation
-- **[Full API Documentation](https://github.com/akash-network/console/wiki/Managed-wallet-API)** - Complete API reference on GitHub
-- **[Example Script](https://github.com/akash-network/console/wiki/Managed-wallet-API)** - Working implementation
+- **[Quickstart](/docs/api-documentation/console-api/quickstart)** - End-to-end deployment in five API calls
 - **[SDL Reference](/docs/developers/deployment/akash-sdl)** - SDL syntax guide
 - **[Console Documentation](/docs/developers/deployment/akash-console)** - Console overview
 

--- a/src/content/Docs/api-documentation/console-api/getting-started/index.md
+++ b/src/content/Docs/api-documentation/console-api/getting-started/index.md
@@ -60,7 +60,7 @@ All examples in this guide show the full response body — extract the value you
 
 ### Money fields
 
-The Managed Wallet bills your Console account in **USD** (credit card). The `deposit` field on `POST /v1/deployments` and `POST /v1/deposit-deployment` is a number in dollars (for example `5.5` = $5.50).
+The Managed Wallet bills your Console account in **USD** (credit card). The `deposit` field on `POST /v1/deployments` and `POST /v1/deposit-deployment` is a number in dollars. The minimum accepted value is `0.5` ($0.50); pass a larger value to top up by more.
 
 The blockchain itself works in raw on-chain denoms (`uact`, `uusdc`, …). Wherever you see `price.denom` / `price.amount` in a bid response or an `escrow_account.state.funds` entry, those are raw chain values in micro-units (1 ACT = 1 000 000 uact). The SDL `pricing` block also uses chain denoms — the managed wallet handles the USD ↔ chain conversion for you.
 
@@ -81,7 +81,7 @@ curl -X POST https://console-api.akash.network/v1/deployments \
   -d '{
     "data": {
       "sdl": "<YOUR_SDL_YAML_AS_STRING>",
-      "deposit": 5.5
+      "deposit": 0.5
     }
   }'
 ```
@@ -95,7 +95,7 @@ const res = await fetch("https://console-api.akash.network/v1/deployments", {
     "x-api-key": process.env.AKASH_API_KEY,
     "Content-Type": "application/json",
   },
-  body: JSON.stringify({ data: { sdl: YOUR_SDL_STRING, deposit: 5.5 } }),
+  body: JSON.stringify({ data: { sdl: YOUR_SDL_STRING, deposit: 0.5 } }),
 });
 const { data } = await res.json();
 const dseq = data.dseq;
@@ -305,7 +305,7 @@ cURL:
 curl -X POST https://console-api.akash.network/v1/deposit-deployment \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{ "data": { "dseq": "1234567", "deposit": 10 } }'
+  -d '{ "data": { "dseq": "1234567", "deposit": 0.5 } }'
 ```
 
 JavaScript (fetch):
@@ -319,7 +319,7 @@ const res = await fetch(
       "x-api-key": process.env.AKASH_API_KEY,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ data: { dseq, deposit: 10 } }),
+    body: JSON.stringify({ data: { dseq, deposit: 0.5 } }),
   },
 );
 const { data } = await res.json();
@@ -445,7 +445,7 @@ async function waitForBids(dseq, { pollMs = 3000, maxAttempts = 20 } = {}) {
 async function main() {
   const create = await apiRequest("/v1/deployments", {
     method: "POST",
-    body: JSON.stringify({ data: { sdl: SDL, deposit: 5.5 } }),
+    body: JSON.stringify({ data: { sdl: SDL, deposit: 0.5 } }),
   });
   const { dseq, manifest } = create.data;
 
@@ -469,7 +469,7 @@ async function main() {
 
   await apiRequest("/v1/deposit-deployment", {
     method: "POST",
-    body: JSON.stringify({ data: { dseq, deposit: 10 } }),
+    body: JSON.stringify({ data: { dseq, deposit: 0.5 } }),
   });
 
   const status = await apiRequest(`/v1/deployments/${dseq}`);

--- a/src/content/Docs/api-documentation/console-api/index.md
+++ b/src/content/Docs/api-documentation/console-api/index.md
@@ -43,12 +43,7 @@ Authentication: pass your API key in every request with `x-api-key: YOUR_API_KEY
 
 ## Changelog
 
-| Date | Version | Change |
-|---|---|---|
-| 2024-01-01 | v2 | Added `/v2/deployment-settings` with auto top-up support |
-| 2023-xx-xx | v1 | Initial release of `/v1/deployments`, bids, leases |
-
-[Full GitHub releases](https://github.com/akash-network/console/releases)
+See the [full GitHub releases](https://github.com/akash-network/console/releases) for the authoritative version history.
 
 ---
 

--- a/src/content/Docs/api-documentation/console-api/quickstart/index.md
+++ b/src/content/Docs/api-documentation/console-api/quickstart/index.md
@@ -12,7 +12,7 @@ Deploy an nginx container to Akash in five API calls.
 Prerequisites:
 
 - An API key from [Console](https://console.akash.network) (Settings → API Keys), exported as `AKASH_API_KEY`.
-- A `deployment.json` file shaped like `{ "data": { "sdl": "<YOUR_SDL_YAML_AS_STRING>", "deposit": 5.5 } }`.
+- A `deployment.json` file shaped like `{ "data": { "sdl": "<YOUR_SDL_YAML_AS_STRING>", "deposit": 0.5 } }` (`deposit` is in USD; `0.5` is the minimum).
 - `jq` for JSON parsing.
 
 ```bash

--- a/src/content/Docs/api-documentation/console-api/quickstart/index.md
+++ b/src/content/Docs/api-documentation/console-api/quickstart/index.md
@@ -9,29 +9,44 @@ description: "Deploy an nginx container to Akash in five API calls"
 
 Deploy an nginx container to Akash in five API calls.
 
-Prerequisites: an API key from [Console](https://console.akash.network) via your profile menu -> API Keys.
+Prerequisites:
+
+- An API key from [Console](https://console.akash.network) (Settings → API Keys), exported as `AKASH_API_KEY`.
+- A `deployment.json` file shaped like `{ "data": { "sdl": "<YOUR_SDL_YAML_AS_STRING>", "deposit": 5.5 } }`.
+- `jq` for JSON parsing.
 
 ```bash
 # 1. Create a deployment
-DSEQ=$(curl -s -X POST https://console-api.akash.network/v1/deployments \
+CREATE=$(curl -s -X POST https://console-api.akash.network/v1/deployments \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d @deployment.json | jq -r .dseq)
+  -d @deployment.json)
+DSEQ=$(echo "$CREATE" | jq -r '.data.dseq')
+MANIFEST=$(echo "$CREATE" | jq -r '.data.manifest')
 
-# 2. Wait 30 seconds for bids, then pick the first
+# 2. Wait 30 seconds for bids, then read the first bid's composite id
 sleep 30
-BID_ID=$(curl -s "https://console-api.akash.network/v1/bids?dseq=$DSEQ" \
-  -H "x-api-key: $AKASH_API_KEY" | jq -r '.[0].id')
+BID=$(curl -s "https://console-api.akash.network/v1/bids?dseq=$DSEQ" \
+  -H "x-api-key: $AKASH_API_KEY" | jq -c '.data[0].bid.id')
+GSEQ=$(echo "$BID" | jq -r '.gseq')
+OSEQ=$(echo "$BID" | jq -r '.oseq')
+PROVIDER=$(echo "$BID" | jq -r '.provider')
 
-# 3. Create lease
+# 3. Create lease — accepts the bid and ships the manifest
 curl -s -X POST https://console-api.akash.network/v1/leases \
   -H "x-api-key: $AKASH_API_KEY" \
   -H "Content-Type: application/json" \
-  -d "{\"dseq\": \"$DSEQ\", \"bidId\": \"$BID_ID\"}"
+  -d "$(jq -n \
+        --arg manifest "$MANIFEST" \
+        --arg dseq "$DSEQ" \
+        --argjson gseq "$GSEQ" \
+        --argjson oseq "$OSEQ" \
+        --arg provider "$PROVIDER" \
+        '{manifest: $manifest, leases: [{dseq: $dseq, gseq: $gseq, oseq: $oseq, provider: $provider}]}')"
 
 # 4. Check status
 curl -s "https://console-api.akash.network/v1/deployments/$DSEQ" \
-  -H "x-api-key: $AKASH_API_KEY"
+  -H "x-api-key: $AKASH_API_KEY" | jq
 
 # 5. Close when done
 curl -s -X DELETE "https://console-api.akash.network/v1/deployments/$DSEQ" \


### PR DESCRIPTION
## Summary

The Console Managed Wallet API docs (`getting-started`, `api-reference`, `quickstart`, landing page) described request/response shapes that don't match the actual API in [akash-network/console](https://github.com/akash-network/console). I cross-checked every endpoint against the live zod schemas in [`apps/api`](https://github.com/akash-network/console/tree/main/apps/api/src) and rewrote the docs so integrators can call the endpoints successfully.

## What was wrong (high-impact)

- All JSON responses are wrapped in a top-level `data` envelope — the docs treated them as flat.
- `POST /v1/deployments` body is `{ data: { sdl, deposit } }` (`deposit` is a **required number in USD**, not optional string). Returns **201**, not 200. Response is `{ data: { dseq, manifest, signTx: { code, transactionHash, rawLog } } }`, not `{ dseq, status, createdAt }`.
- `GET /v1/bids` returns each bid as `{ bid: { id: { owner, dseq, gseq, oseq, provider, bseq }, state, price: { denom, amount }, ... }, escrow_account }`. There is **no flat `bid.id` string** — the bid is identified by the composite id.
- `POST /v1/leases` body is `{ manifest, leases: [{ dseq, gseq, oseq, provider }] }`, **not** `{ dseq, bidId }`. Response is the full deployment object, same shape as `GET /v1/deployments/{dseq}`.
- `POST /v1/deposit-deployment` body is `{ data: { dseq, deposit: <USD number> } }`, **not** `{ dseq, amount: "<string>" }`. Response is the full deployment object.
- `DELETE /v1/deployments/{dseq}` returns `{ data: { success: true } }`, not `{ dseq, status, refundedAmount, closedAt }`.
- `GET /v1/deployments` defaults `limit` to **1000** (docs said 10/max 100) and returns `{ data: { deployments, pagination: { total, skip, limit, hasMore } } }`.
- v2 deployment-settings fields are `autoTopUpEnabled` / `estimatedTopUpAmount` / `topUpFrequencyMs`, **not** `autoTopUp` / `topUpThreshold` / `topUpAmount`. `PATCH /v2/deployment-settings/{dseq}` exists and is now documented.

## What changed in this PR

- `getting-started/index.md` — added a "Response envelope" and "Money fields" section up front, then rewrote every endpoint example (request body, response body) against the live schemas. Updated the end-to-end script accordingly.
- `api-reference/index.md` — rebuilt each endpoint table-by-table from the zod schemas. Fixed pagination defaults. Added `PATCH /v2/deployment-settings/{dseq}`. Removed inaccurate field tables.
- `quickstart/index.md` — fixed the bash flow to use `.data[0].bid.id` and build the real `{ manifest, leases: [...] }` lease body.
- Landing page — dropped the placeholder `2023-xx-xx` changelog row; the GitHub releases page is the authoritative version history.

## Source of truth

- Routes: `apps/api/src/deployment/routes/deployments/deployments.router.ts`, `apps/api/src/bid/routes/bids/bids.router.ts`, `apps/api/src/deployment/routes/leases/leases.router.ts`, `apps/api/src/deployment/routes/deployment-setting/deployment-setting.router.ts`
- Schemas: `apps/api/src/deployment/http-schemas/{deployment,lease,deployment-setting}.schema.ts`, `apps/api/src/bid/http-schemas/bid.schema.ts`, `apps/api/src/billing/http-schemas/tx.schema.ts`

## Test plan

- [ ] `npm run dev` and visit `/docs/api-documentation/console-api/getting-started`, `/api-reference`, `/quickstart` — spot-check that all four pages render and the code blocks look reasonable.
- [ ] Optional but recommended: run the example script in `getting-started/index.md` against a staging API key on `console-api.akash.network` to confirm the bash and JS snippets work end-to-end.
- [ ] Compare each endpoint section side-by-side with the corresponding zod schema in `akash-network/console` and confirm the field names / types match.