### PR TITLE
docs(sdl): expand permissions guidance and cross-link deployments page

### DIFF
--- a/src/content/Docs/developers/deployment/akash-sdl/syntax-reference/index.mdx
+++ b/src/content/Docs/developers/deployment/akash-sdl/syntax-reference/index.mdx
@@ -262,6 +262,8 @@ params:
 | `logs` | `get/list/watch` on `pods`, `get` on `pods/log`, `get/list/watch` on `apps/deployments` |
 | `events` | `get/list/watch` on `events` |
 
+**Typical use:** log-forwarding sidecars that ship stdout/stderr to an external destination (Datadog, Loki, Fluent Bit, the Akash log-collector image), or monitoring agents that observe pod restarts, OOM kills, scheduling failures, and other lifecycle transitions.
+
 The collector pod authenticates against the Kubernetes API using a ServiceAccount the provider mounts into every container. When the target service declares `permissions.read`, the provider attaches a matching `Role` and `RoleBinding` so collectors in the same deployment can call the API server. See [Log Forwarding](/docs/developers/deployment/akash-sdl/advanced-features#log-forwarding) for the full sidecar pattern.
 
 </div>

--- a/src/content/Docs/learn/core-concepts/deployments/index.md
+++ b/src/content/Docs/learn/core-concepts/deployments/index.md
@@ -343,6 +343,8 @@ deployment:
 
 In this example, `log-collector` can read logs and events from both itself and the `web` service. The `web` service has no special permissions — it runs with default access only.
 
+For the formal field syntax, see the [`params.permissions`](/docs/developers/deployment/akash-sdl/syntax-reference#permissions-section) section of the SDL Syntax Reference.
+
 ---
 
 ## Escrow Accounts


### PR DESCRIPTION
Addresses PR #1134 review feedback.

Expands the `params.permissions` section in the SDL syntax reference with the why/when context the reviewer asked for, matching the descriptive tone of the existing **Deployment Permissions** concept page so the two pages reinforce each other instead of duplicating jargon.

Also corrects the direction of the grant: declaring `permissions.read` on a service grants **that service** access to its peers' logs and events, not the other way around. Verified against [`provider/cluster/kube/builder/rolebinding.go`](https://github.com/akash-network/provider/blob/main/cluster/kube/builder/rolebinding.go) — the RoleBinding subject is the declaring workload's own ServiceAccount.

Adds cross-links in both directions:
- SDL reference → `learn/core-concepts/deployments#deployment-permissions` for the higher-level concept and full SDL example.
- Deployments page → `developers/deployment/akash-sdl/syntax-reference#permissions-section` for the formal field syntax.