### PR TITLE
docs: fix Console wallet bold formatting

### DIFF
--- a/src/content/Docs/developers/deployment/akash-console/with-wallet/index.md
+++ b/src/content/Docs/developers/deployment/akash-console/with-wallet/index.md
@@ -86,7 +86,7 @@ Open your browser and go to **[console.akash.network](https://console.akash.netw
 ![Mint ACT](/images/docs/console/wallet/5-mint-act.png)
 *Mint ACT*
 
-**You're now connected with your own wallet with both AKT and ACT!
+**You're now connected with your own wallet with both AKT and ACT!**
 
 ---
 
@@ -175,7 +175,7 @@ Click **"Approve"**
 
  Wait ~30 seconds for blockchain confirmation
 
-**Deployment created! Now waiting for provider bids...
+**Deployment created! Now waiting for provider bids...**
 
 ---
 


### PR DESCRIPTION
## Summary
- closes two unclosed bold markers in the Console wallet deployment guide
- prevents the status lines from rendering with visible Markdown syntax

## Verification
- inspected the current docs source and confirmed both lines opened `**` without closing it
- ran `git diff --check` locally against this single-file change