### PR TITLE
docs: update provider-services install requirements

### DIFF
--- a/src/content/Docs/developers/deployment/cli/installation-guide/index.mdx
+++ b/src/content/Docs/developers/deployment/cli/installation-guide/index.mdx
@@ -54,7 +54,7 @@ provider-services version
 **Expected Output**
 
 ```
-v0.10.0
+v0.12.0
 ```
 
 </TabContent>
@@ -101,7 +101,7 @@ provider-services version
 **Expected Output**
 
 ```
-v0.10.0
+v0.12.0
 ```
 
   </TabContent>
@@ -143,7 +143,7 @@ $ make install
 
 **Requirements:**
 
-- [golang 1.21+](https://golang.org/)
+- [Go 1.25.5+](https://go.dev/doc/install)
 - Properly set `GOPATH`
 - `$GOPATH/bin` present in `$PATH`
 


### PR DESCRIPTION
## Summary
- updates the provider-services CLI expected version output to the current v0.12.0 release
- updates the source-build Go requirement to match the provider repository's current go.mod

## Verification
- confirmed the latest provider release is v0.12.0 via the GitHub Releases API
- confirmed akash-network/provider main go.mod declares Go 1.25.5
- reviewed the final diff and kept the code changes scoped to the installation guide