### PR TITLE
docs: fix provider verification log formatting

### DIFF
--- a/src/content/Docs/providers/operations/provider-verification/index.md
+++ b/src/content/Docs/providers/operations/provider-verification/index.md
@@ -33,9 +33,9 @@ kubectl -n akash-services logs -l app=akash-provider --tail=100 -f
 ```
 
 **Look for:**
-- **`"bidding on order"` - Provider is creating bids
-- **`"bid complete"` - Bids are being submitted
-- **`"error"` or `"failed"` - Investigate errors
+- **`"bidding on order"`** - Provider is creating bids
+- **`"bid complete"`** - Bids are being submitted
+- **`"error"` or `"failed"`** - Investigate errors
 
 ### 3. Verify On-Chain Registration
 


### PR DESCRIPTION
## Summary
- closes the bold markers around provider log snippets in the verification guide
- prevents the troubleshooting checklist from rendering raw Markdown syntax

## Verification
- inspected the Markdown source and confirmed each affected line opened `**` without closing it around the log text
- reviewed the final diff to confirm the change is scoped to the provider verification checklist