### PR TITLE
docs: replace dead Ping.pub validator link

### DIFF
--- a/src/content/Docs/node-operators/validators/tmkms-stunnel/index.md
+++ b/src/content/Docs/node-operators/validators/tmkms-stunnel/index.md
@@ -690,7 +690,7 @@ akash query staking validator $(akash keys show $AKASH_KEYNAME --bech val -a)
 
 Check on [Akash Block Explorers](/docs/node-operators/validators/):
 - [Mintscan](https://www.mintscan.io/akash/validators)
-- [Ping.pub](https://ping.pub/akash/staking)
+- [Akash Valopers](https://akash.valopers.com/validators)
 
 ---
 


### PR DESCRIPTION
## Summary
- replaces the dead Ping.pub Akash staking link in the TMKMS/stunnel guide
- keeps the validator explorer list useful with an Akash-specific Valopers validator page

## Verification
- confirmed `https://ping.pub/akash/staking` currently returns 404
- confirmed `https://akash.valopers.com/validators` currently returns 200
- reviewed the final diff to confirm this is a one-link documentation fix