### PR TITLE
docs: fix gateway migration chart version

### DIFF
--- a/src/content/Docs/providers/operations/gateway-api-migration/index.md
+++ b/src/content/Docs/providers/operations/gateway-api-migration/index.md
@@ -222,7 +222,7 @@ NAME                              CHART VERSION    APP VERSION
 akash/akash-hostname-operator     16.0.0           0.12.0
 akash/akash-inventory-operator    16.0.0           0.12.0
 akash/akash-ip-operator           16.0.0           0.12.0
-akash/akash-node                  17.1.1           2.0.1
+akash/akash-node                  17.0.0           2.0.1
 akash/provider                    16.0.0           0.12.0
 ```
 


### PR DESCRIPTION
## Summary
- correct the expected `helm search repo akash` output for the `akash/akash-node` chart version

## Verification
- checked the live Akash Helm chart index at https://akash-network.github.io/helm-charts/index.yaml
- confirmed `akash-node` app version `2.0.1` is published as chart version `17.0.0`
- ran `git diff --check`