### PR TITLE
docs: fix Mainnet 17 Go requirement

### DIFF
--- a/src/content/Docs/node-operators/network-upgrades/mainnet-17/index.md
+++ b/src/content/Docs/node-operators/network-upgrades/mainnet-17/index.md
@@ -261,7 +261,7 @@ Ensure the following dependencies are installed before building:
 
 | Dependency | Minimum Version | Notes |
 |------------|-----------------|-------|
-| golang | >= 1.26 | Required for compiling Go code |
+| Go | >= 1.25.5 | Required for compiling Go code |
 | direnv | latest | Environment management - [direnv.net](https://direnv.net) |
 | docker | latest | Required for containerized builds |
 | make | latest | Build automation |


### PR DESCRIPTION
## Summary
- correct the Mainnet 17 source-build Go requirement to match the Akash node v2.0.0 release tag
- use the standard `Go` toolchain name in the dependency table

## Verification
- checked https://raw.githubusercontent.com/akash-network/node/v2.0.0/go.mod
- confirmed the release tag used by the guide declares `go 1.25.5`
- ran `git diff --check`