### PR TITLE
docs: fix Kubespray checklist formatting

### DIFF
--- a/src/content/Docs/providers/setup-and-installation/kubespray/kubernetes-setup/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/kubernetes-setup/index.md
@@ -29,10 +29,10 @@ Using Kubespray 2.31.0, you'll install:
 ## Before You Begin
 
 Ensure you have:
-- **Reviewed [Hardware Requirements](/docs/providers/getting-started/hardware-requirements)
-- **Ubuntu 24.04 LTS installed on all nodes
-- **Root or sudo access to all nodes
-- **Network connectivity between all nodes
+- **Reviewed [Hardware Requirements](/docs/providers/getting-started/hardware-requirements)**
+- **Ubuntu 24.04 LTS installed on all nodes**
+- **Root or sudo access to all nodes**
+- **Network connectivity between all nodes**
 
 ---
 


### PR DESCRIPTION
## Summary
- close the bold markers in the Kubespray Kubernetes setup prerequisites checklist
- keep the existing hardware requirements link intact

## Verification
- inspected the rendered Markdown source around the `Before You Begin` checklist
- ran `git diff --check`