### PR TITLE
docs: fix SDL best practices formatting

### DIFF
--- a/src/content/Docs/developers/deployment/akash-sdl/best-practices/index.md
+++ b/src/content/Docs/developers/deployment/akash-sdl/best-practices/index.md
@@ -510,7 +510,7 @@ deployments/
 
 ## Common Pitfalls to Avoid
 
-### **Don't Use Excessive Resources
+### **Don't Use Excessive Resources**
 
 ```yaml
 # Wastes money and reduces available providers
@@ -520,7 +520,7 @@ memory:
   size: 128Gi
 ```
 
-### **Don't Expose Databases Publicly
+### **Don't Expose Databases Publicly**
 
 ```yaml
 # Security risk!
@@ -529,18 +529,18 @@ services:
     expose:
       - port: 5432
         to:
-          - global: true      # **Never do this
+          - global: true      # Never do this
 ```
 
-### **Don't Use Ephemeral Storage for Databases
+### **Don't Use Ephemeral Storage for Databases**
 
 ```yaml
 # Data loss on restart!
 storage:
-  - size: 10Gi              # **Not persistent
+  - size: 10Gi              # Not persistent
 ```
 
-### **Don't Forget to Set Pricing
+### **Don't Forget to Set Pricing**
 
 ```yaml
 # Will fail to deploy without pricing


### PR DESCRIPTION
## Summary
- close bold markers in the SDL best-practices pitfall headings
- remove stray Markdown bold markers from YAML comments that are meant to render literally

## Verification
- inspected the affected Markdown around the Common Pitfalls section
- ran git diff --check