### PR TITLE
docs: fix development environment platform formatting

### DIFF
--- a/src/content/Docs/developers/contributing/development-environment/index.md
+++ b/src/content/Docs/developers/contributing/development-environment/index.md
@@ -192,9 +192,9 @@ git clone https://github.com/akash-network/provider.git
 ```
 
 **Supported platforms:**
-- **macOS
-- **Debian-based Linux
-- **Windows (not supported - use WSL2)
+- **macOS**
+- **Debian-based Linux**
+- **Windows (not supported - use WSL2)**
 
 ---
 


### PR DESCRIPTION
## Summary
- close bold markers in the supported-platforms list for the development environment guide

## Verification
- inspected the supported-platforms Markdown list
- ran git diff --check