### PR TITLE
docs: fix persistent storage heading formatting

### DIFF
--- a/src/content/Docs/learn/core-concepts/persistent-storage/index.md
+++ b/src/content/Docs/learn/core-concepts/persistent-storage/index.md
@@ -244,13 +244,13 @@ services:
 
 ## Storage Persistence Guarantees
 
-### **Survives
+### **Survives**
 
 - **Container restarts** - Data persists if container crashes or restarts
 - **Deployment updates** - Data persists when you update image version, env vars, etc.
 - **Provider restarts** - Data persists if provider's infrastructure restarts
 
-### **Does NOT Survive
+### **Does NOT Survive**
 
 - **Lease termination** - Data is lost when you close the deployment
 - **Provider migration** - Data is lost if you move to a different provider


### PR DESCRIPTION
## Summary
- close bold markers in the persistent storage persistence-guarantees headings

## Verification
- inspected the affected headings in the persistent storage page
- ran git diff --check