### PR TITLE
docs: fix environment secrets YAML comments

### DIFF
--- a/src/content/Docs/learn/core-concepts/environment-secrets/index.md
+++ b/src/content/Docs/learn/core-concepts/environment-secrets/index.md
@@ -528,22 +528,22 @@ env:
 
 **Problem: Variable with spaces**
 ```yaml
-# **WRONG - will break
+# WRONG - will break
 env:
   - MESSAGE=Hello World
 
-# **CORRECT - quote the value
+# CORRECT - quote the value
 env:
   - MESSAGE="Hello World"
 ```
 
 **Problem: Special characters**
 ```yaml
-# **WRONG - special chars may break
+# WRONG - special chars may break
 env:
   - PASSWORD=p@$$w0rd!
 
-# **CORRECT - escape or quote
+# CORRECT - escape or quote
 env:
   - PASSWORD="p@$$w0rd!"
 ```


### PR DESCRIPTION
## Summary
- remove stray Markdown bold markers from YAML comments in the environment secrets examples

## Verification
- inspected the affected YAML code fences to confirm the comments render literally
- ran git diff --check