### PR TITLE
docs: fix provider getting started list formatting

### DIFF
--- a/src/content/Docs/providers/getting-started/index.md
+++ b/src/content/Docs/providers/getting-started/index.md
@@ -45,9 +45,9 @@ Before diving into provider operations, you should have:
 
 By the end of this section, you'll know:
 
-**If running a provider is right for you  
-**What hardware and resources you need  
-**How to calculate your potential earnings  
-**How to get started with setup  
+- **If running a provider is right for you**
+- **What hardware and resources you need**
+- **How to calculate your potential earnings**
+- **How to get started with setup**
 
 ---


### PR DESCRIPTION
## Summary
- convert the What You'll Learn lines into a proper Markdown list
- close the bold markers on each item

## Verification
- inspected the provider getting-started overview around the affected section
- ran git diff --check