### PR TITLE
docs: fix Kubespray advantages heading

### DIFF
--- a/src/content/Docs/providers/setup-and-installation/kubespray/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/index.md
@@ -29,7 +29,7 @@ Kubespray is a composition of Ansible playbooks, inventory, provisioning tools, 
 
 ## Why Choose Kubespray?
 
-### **Advantages
+### **Advantages**
 - **Full control** - Customize every aspect of your setup
 - **Production-grade** - Battle-tested for large deployments
 - **Deep understanding** - Learn exactly how components work together


### PR DESCRIPTION
## Summary
- close the bold marker in the Kubespray advantages heading

## Verification
- inspected the affected heading in the Kubespray setup page
- ran git diff --check