### PR TITLE
docs: update TMKMS stunnel Omnibus example

### DIFF
--- a/src/content/Docs/node-operators/validators/tmkms-stunnel/index.md
+++ b/src/content/Docs/node-operators/validators/tmkms-stunnel/index.md
@@ -185,7 +185,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.35-akash-v1.1.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.43-akash-v2.0.1
     env:
       - MONIKER=my-validator  # Change this
       - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/mainnet/meta.json
@@ -593,8 +593,8 @@ sudo journalctl -u tmkms -f --lines 50
 ```
 
 **Look for:**
-- **`connected to validator successfully`
-- **Signing messages (height increasing)
+- **`connected to validator successfully`**
+- **Signing messages (height increasing)**
 
 ### Check Akash Validator Logs
 
@@ -605,9 +605,9 @@ In [Akash Console](https://console.akash.network):
 3. Select **"node"** service
 
 **Look for:**
-- **`executed block height=...`
-- **`committed state height=...`
-- **Height increasing continuously
+- **`executed block height=...`**
+- **`committed state height=...`**
+- **Height increasing continuously**
 
 ### Check Stunnel Proxy Logs
 


### PR DESCRIPTION
## Summary
- update the TMKMS stunnel SDL to the current cosmos-omnibus image tag used by the upstream Akash example
- close bold markers in the TMKMS and validator log-check lists

## Verification
- checked the latest akash-network/cosmos-omnibus release: v1.2.43, published 2026-04-20
- checked the official validator-and-tmkms example, which uses ghcr.io/akash-network/cosmos-omnibus:v1.2.43-akash-v2.0.1
- inspected the affected Markdown lists
- ran git diff --check