### PR TITLE
docs: update node build Omnibus image

### DIFF
--- a/src/content/Docs/node-operators/node-build/omnibus/index.md
+++ b/src/content/Docs/node-operators/node-build/omnibus/index.md
@@ -26,7 +26,7 @@ version: "2.0"
 
 services:
   node:
-    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.35-akash-v1.1.0
+    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.43-akash-v2.0.1
     env:
       - MONIKER=my-akash-node
       - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/mainnet/meta.json


### PR DESCRIPTION
## Summary
- update the node-build Omnibus SDL image tag from v1.2.35-akash-v1.1.0 to v1.2.43-akash-v2.0.1

## Verification
- checked the latest akash-network/cosmos-omnibus release: v1.2.43, published 2026-04-20
- checked official Akash cosmos-omnibus examples using ghcr.io/akash-network/cosmos-omnibus:v1.2.43-akash-v2.0.1
- ran git diff --check