### PR TITLE
docs: remove stray markers from SDK examples

### DIFF
--- a/src/content/Docs/api-documentation/sdk/examples/index.mdx
+++ b/src/content/Docs/api-documentation/sdk/examples/index.mdx
@@ -1083,7 +1083,7 @@ func main() {
         panic(err)
     }
     
-    fmt.Printf("**Deployment created with dseq: %d\\n", dseq)
+    fmt.Printf("Deployment created with dseq: %d\\n", dseq)
     
     // 7. Wait for bids
     fmt.Println("Waiting for bids...")
@@ -1120,7 +1120,7 @@ func main() {
             panic(err)
         }
         
-        fmt.Println("**Lease created!")
+        fmt.Println("Lease created!")
         fmt.Printf("Provider: %s\\n", selectedBid.BidID.Provider)
         fmt.Printf("Deployment: %d-%d-%d\\n", 
             selectedBid.BidID.DSeq, 
@@ -1142,4 +1142,3 @@ func main() {
 - [Quick Start](/docs/api-documentation/sdk/quick-start)
 - [API Reference](/docs/api-documentation/sdk/api-reference)
 - [SDL Reference](/docs/developers/deployment/akash-sdl)
-

--- a/src/content/Docs/api-documentation/sdk/quick-start/index.mdx
+++ b/src/content/Docs/api-documentation/sdk/quick-start/index.mdx
@@ -259,7 +259,7 @@ const deployment = await sdk.akash.deployment.v1beta4.createDeployment({
   depositor: accounts[0].address
 });
 
-console.log("**Deployment created with dseq:", dseq);`
+console.log("Deployment created with dseq:", dseq);`
     },
     {
       language: "go",
@@ -315,7 +315,7 @@ if err != nil {
     panic(err)
 }
 
-fmt.Printf("**Deployment created with dseq: %d\\n", dseq)`
+fmt.Printf("Deployment created with dseq: %d\\n", dseq)`
     }
   ]}
 />
@@ -415,7 +415,7 @@ const lease = await sdk.akash.market.v1beta5.createLease({
   bidId: selectedBid.bidId
 });
 
-console.log("**Lease created!");
+console.log("Lease created!");
 console.log(\`Provider: \${selectedBid.bidId.provider}\`);`
     },
     {
@@ -441,7 +441,7 @@ if err != nil {
     panic(err)
 }
 
-fmt.Println("**Lease created!")
+fmt.Println("Lease created!")
 fmt.Printf("Provider: %s\\n", selectedBid.BidID.Provider)`
     }
   ]}
@@ -495,7 +495,7 @@ const response = await fetch(
 );
 
 if (response.ok) {
-  console.log("**Manifest sent successfully!");
+  console.log("Manifest sent successfully!");
   console.log("Your deployment is now starting...");
 } else {
   console.error("Failed to send manifest:", await response.text());
@@ -520,7 +520,7 @@ if err != nil {
 // 2. Generate JWT token or use mTLS certificate
 // 3. Send manifest via HTTP PUT request to provider
 
-fmt.Println("**Manifest ready to send!")
+fmt.Println("Manifest ready to send!")
 fmt.Println("Your deployment is now starting...")
 
 // For full manifest sending implementation, see the Examples page`


### PR DESCRIPTION
## Summary
- remove stray Markdown bold markers from SDK console and fmt output examples
- keep the sample code behavior the same while making copied output strings clean

## Verification
- searched the SDK quick start and examples pages for remaining `"**` output strings
- ran `git diff --check`