### PR TITLE
docs: use supported fence language for AkashML env example

### DIFF
--- a/src/content/Docs/developers/guides/linkedin-roast-app/index.md
+++ b/src/content/Docs/developers/guides/linkedin-roast-app/index.md
@@ -83,7 +83,7 @@ bun run dev:frontend
 
 ### Environment Variables
 
-```env
+```bash
 VITE_AKASHML_API_KEY=your-api-key-here
 ```
 


### PR DESCRIPTION
## Summary
- change the AkashML environment-variable code fence from `env` to `bash`
- avoid the unsupported-language warning emitted by the docs build

## Verification
- reproduced the docs build warning for the `env` fence in this page during the combined audit build
- ran `git diff --check`