### PR TITLE
docs: clarify console image path example

### DIFF
--- a/src/content/Docs/developers/contributing/console-website-setup/index.md
+++ b/src/content/Docs/developers/contributing/console-website-setup/index.md
@@ -566,8 +566,8 @@ npm run build
 ls -la public/images/
 
 # Use absolute paths in markdown
-# **![Alt](/images/pic.png)
-# **![Alt](./images/pic.png)
+# Correct: ![Alt](/images/pic.png)
+# Incorrect: ![Alt](./images/pic.png)
 ```
 
 **MDX parsing errors:**
@@ -694,4 +694,3 @@ Ready to contribute?
 ---
 
 **Questions?** Ask in [Discord #developers](https://discord.akash.network)!
-


### PR DESCRIPTION
## Summary
- replace stray bold markers in the image-path troubleshooting snippet with explicit correct/incorrect labels
- preserve the guidance that website images should use absolute public paths

## Verification
- inspected the console website setup troubleshooting example
- ran `git diff --check`