### PR TITLE
docs: fix PR feedback response examples

### DIFF
--- a/src/content/Docs/developers/contributing/pull-request-process/index.md
+++ b/src/content/Docs/developers/contributing/pull-request-process/index.md
@@ -211,19 +211,19 @@ Your PR will trigger:
 **Good responses:**
 
 ```markdown
-**"Great catch! Fixed in latest commit."
-**"I considered that approach but chose X because Y. Thoughts?"
-**"Good point. Changed to use interface instead."
-**"Can you clarify what you mean by...?"
+- "Great catch! Fixed in latest commit."
+- "I considered that approach but chose X because Y. Thoughts?"
+- "Good point. Changed to use interface instead."
+- "Can you clarify what you mean by...?"
 ```
 
 **Avoid:**
 
 ```markdown
-**"This is fine as-is."
-**No response (ignoring feedback)
-**"You're wrong."
-**Defensive or argumentative responses
+- "This is fine as-is."
+- No response (ignoring feedback)
+- "You're wrong."
+- Defensive or argumentative responses
 ```
 
 #### Making Changes


### PR DESCRIPTION
## Summary
- replace stray bold markers in PR feedback examples with valid Markdown list items
- make the good/avoid examples render cleanly in the fenced Markdown block

## Verification
- inspected the pull request process response examples
- ran `git diff --check`