### PR TITLE
docs: fix Console wallet status formatting

### DIFF
--- a/src/content/Docs/developers/deployment/akash-console/with-wallet/index.md
+++ b/src/content/Docs/developers/deployment/akash-console/with-wallet/index.md
@@ -86,7 +86,7 @@ Open your browser and go to **[console.akash.network](https://console.akash.netw
 ![Mint ACT](/images/docs/console/wallet/5-mint-act.png)
 *Mint ACT*
 
-**You're now connected with your own wallet with both AKT and ACT!
+**You're now connected with your own wallet with both AKT and ACT!**
 
 ---
 
@@ -175,7 +175,7 @@ Click **"Approve"**
 
  Wait ~30 seconds for blockchain confirmation
 
-**Deployment created! Now waiting for provider bids...
+**Deployment created! Now waiting for provider bids...**
 
 ---
 
@@ -238,7 +238,7 @@ You'll see:
 -  **Cost Tracking** - Current spending and escrow balance
 -  **Management Controls** - Logs, update, close
 
-** Congratulations! Your app is live on Akash!**
+**Congratulations! Your app is live on Akash!**
 
 ---
 
@@ -428,4 +428,3 @@ Stop your deployment and reclaim your deposit:
 ---
 
 **Ready to deploy?** [Visit Console →](https://console.akash.network)
-


### PR DESCRIPTION
## Summary
- close bold formatting on Console wallet status messages
- remove an extra leading space from the final success message

## Verification
- scanned the Console wallet page for odd-numbered bold markers
- ran `git diff --check`