### PR TITLE
docs: fix SDL examples contribution list

### DIFF
--- a/src/content/Docs/developers/deployment/akash-sdl/examples-library/index.md
+++ b/src/content/Docs/developers/deployment/akash-sdl/examples-library/index.md
@@ -297,12 +297,12 @@ The Awesome Akash repository welcomes contributions from the community!
 
 ### Contribution Guidelines
 
-- **Test your SDL before submitting
-- **Include clear, detailed documentation
-- **Specify exact resource requirements
-- **Add troubleshooting tips for common issues
-- **Follow the existing folder structure
-- **Use descriptive commit messages
+- Test your SDL before submitting
+- Include clear, detailed documentation
+- Specify exact resource requirements
+- Add troubleshooting tips for common issues
+- Follow the existing folder structure
+- Use descriptive commit messages
 
 **[View Contributing Guide →](https://github.com/akash-network/awesome-akash/blob/master/CONTRIBUTING.md)**
 


### PR DESCRIPTION
## Summary
- remove unclosed bold markers from the SDL examples contribution guideline list
- render the guidelines as normal list items

## Verification
- scanned the SDL examples library page for odd-numbered bold markers
- ran `git diff --check`