### PR TITLE
docs: fix TMKMS verification list formatting

### DIFF
--- a/src/content/Docs/node-operators/validators/tmkms-stunnel/index.md
+++ b/src/content/Docs/node-operators/validators/tmkms-stunnel/index.md
@@ -593,8 +593,8 @@ sudo journalctl -u tmkms -f --lines 50
 ```
 
 **Look for:**
-- **`connected to validator successfully`
-- **Signing messages (height increasing)
+- `connected to validator successfully`
+- Signing messages (height increasing)
 
 ### Check Akash Validator Logs
 
@@ -605,9 +605,9 @@ In [Akash Console](https://console.akash.network):
 3. Select **"node"** service
 
 **Look for:**
-- **`executed block height=...`
-- **`committed state height=...`
-- **Height increasing continuously
+- `executed block height=...`
+- `committed state height=...`
+- Height increasing continuously
 
 ### Check Stunnel Proxy Logs
 


### PR DESCRIPTION
## Summary
- remove unclosed bold markers from TMKMS and validator log checklist items
- preserve code formatting for the log strings readers should look for

## Verification
- scanned the TMKMS stunnel page for odd-numbered bold markers
- ran `git diff --check`