### PR TITLE
docs: use supported proto fences in AEPs

### DIFF
--- a/src/content/aeps/aep-37/README.md
+++ b/src/content/aeps/aep-37/README.md
@@ -47,7 +47,7 @@ By migrating to gRPC, we expect to achieve better performance, efficiency, and m
 Implement `akash.provider.lease.v1.LeaseRPC` with following types and RPC calls
 
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.provider.lease.v1;
 

--- a/src/content/aeps/aep-76/README.md
+++ b/src/content/aeps/aep-76/README.md
@@ -279,7 +279,7 @@ Mint non-transferable ACT credits by removing AKT from circulation.
 
 ##### Message
 
-```protobuf
+```proto
 MsgMintACT {
   // who provides AKT (tenant or console wallet)
   payer:   Address       
@@ -346,7 +346,7 @@ Tenant burns unused ACT and receives AKT back at **current price**.
 
 ##### Message
 
-```protobuf
+```proto
 MsgBurnACT {
   owner:      Address    // whose ACT to burn
   to:         Address    // who receives AKT (default = owner)

--- a/src/content/aeps/aep-80/README.md
+++ b/src/content/aeps/aep-80/README.md
@@ -44,7 +44,7 @@ No existing Cosmos SDK module provides this combination. The `x/oracle` module f
 
 Uniquely identifies a price pair.
 
-```protobuf
+```proto
 message DataID {
   string denom = 1;       // Asset denomination (e.g., "uakt")
   string base_denom = 2;  // Base denomination (e.g., "usd")
@@ -55,7 +55,7 @@ message DataID {
 
 Identifies a price from a specific source.
 
-```protobuf
+```proto
 message PriceDataID {
   uint32 source = 1;      // Oracle provider index (assigned sequentially)
   string denom = 2;
@@ -67,7 +67,7 @@ message PriceDataID {
 
 Complete price record identifier including block height, enabling range queries.
 
-```protobuf
+```proto
 message PriceDataRecordID {
   uint32 source = 1;
   string denom = 2;
@@ -80,7 +80,7 @@ message PriceDataRecordID {
 
 The price value and its publish timestamp.
 
-```protobuf
+```proto
 message PriceDataState {
   string                    price = 1;     // cosmos.Dec (must be positive)
   google.protobuf.Timestamp timestamp = 2; // Publisher timestamp
@@ -91,7 +91,7 @@ message PriceDataState {
 
 The computed aggregate output stored per `DataID` at the end of each block.
 
-```protobuf
+```proto
 message AggregatedPrice {
   string                    denom = 1;
   string                    twap = 2;           // Time-weighted average price
@@ -108,7 +108,7 @@ message AggregatedPrice {
 
 Health status computed alongside aggregation.
 
-```protobuf
+```proto
 message PriceHealth {
   string          denom = 1;
   bool            is_healthy = 2;           // has_min_sources AND deviation_ok
@@ -138,7 +138,7 @@ Custom codecs encode composite keys with length-prefixed strings and big-endian 
 
 ### Parameters
 
-```protobuf
+```proto
 message Params {
   repeated string              sources = 1;                    // Authorized source addresses
   uint32                       min_price_sources = 2;          // Min sources for valid price
@@ -163,7 +163,7 @@ message Params {
 
 The `feed_contracts_params` field uses `google.protobuf.Any` to store typed configuration for different oracle integrations:
 
-```protobuf
+```proto
 message PythContractParams {
   string akt_price_feed_id = 1;  // Pyth price feed ID for AKT/USD
 }
@@ -181,7 +181,7 @@ These are read by the custom CosmWasm querier (see [CosmWasm Integration](#cosmw
 
 Submits a new price from an authorized source.
 
-```protobuf
+```proto
 service Msg {
   rpc AddPriceEntry(MsgAddPriceEntry) returns (MsgAddPriceEntryResponse);
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
@@ -208,7 +208,7 @@ On success, the price is stored with a `PriceDataRecordID` keyed to the current 
 
 Governance-only message to update module parameters.
 
-```protobuf
+```proto
 message MsgUpdateParams {
   string authority = 1;  // x/gov module account
   Params params = 2;
@@ -258,7 +258,7 @@ At the end of every block, the module runs aggregation:
 
 ### Queries
 
-```protobuf
+```proto
 service Query {
   // Historical price data with pagination
   rpc Prices(QueryPricesRequest) returns (QueryPricesResponse);
@@ -291,7 +291,7 @@ service Query {
 
 ### Events
 
-```protobuf
+```proto
 // Emitted on successful price submission
 message EventPriceData {
   string         source = 1;  // Source address
@@ -400,7 +400,7 @@ Returns guardian addresses as base64
 
 ### Genesis State
 
-```protobuf
+```proto
 message GenesisState {
   Params                params = 1;
   repeated PriceData    prices = 2;

--- a/src/content/aeps/aep-82/IMPLEMENTATION.md
+++ b/src/content/aeps/aep-82/IMPLEMENTATION.md
@@ -127,7 +127,7 @@ if lease.State != mv1.LeaseActive && lease.State != mv1.LeaseReclaiming {
 
 ### 2.1 New File: `proto/node/akash/market/v1/reclamation.proto`
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.market.v1;
 
@@ -185,7 +185,7 @@ message Reclamation {
 
 Add to `Lease.State` enum:
 
-```protobuf
+```proto
 // LeaseReclaiming denotes a lease in reclamation (grace period before closure).
 reclaiming = 4 [
     (gogoproto.enumvalue_customname) = "LeaseReclaiming"
@@ -194,7 +194,7 @@ reclaiming = 4 [
 
 Add field to `Lease` message:
 
-```protobuf
+```proto
 // Reclamation holds reclamation configuration and state, if applicable.
 // Nil if reclamation is not configured for this lease.
 Reclamation reclamation = 7 [
@@ -208,7 +208,7 @@ Reclamation reclamation = 7 [
 
 Add:
 
-```protobuf
+```proto
 // EventLeaseReclaimStarted is triggered when a provider initiates reclamation.
 message EventLeaseReclaimStarted {
   option (gogoproto.equal) = true;
@@ -237,7 +237,7 @@ message EventLeaseReclaimStarted {
 
 Add:
 
-```protobuf
+```proto
 // MsgLeaseStartReclaim is sent by the provider to initiate reclamation on an active lease.
 message MsgLeaseStartReclaim {
   option (gogoproto.equal) = false;
@@ -263,7 +263,7 @@ message MsgLeaseStartReclaimResponse {}
 
 Add RPC to `service Msg`:
 
-```protobuf
+```proto
 // LeaseStartReclaim initiates the reclamation window on an active lease.
 rpc LeaseStartReclaim(MsgLeaseStartReclaim) returns (MsgLeaseStartReclaimResponse);
 ```
@@ -272,7 +272,7 @@ rpc LeaseStartReclaim(MsgLeaseStartReclaim) returns (MsgLeaseStartReclaimRespons
 
 Add to `MsgCreateBid`:
 
-```protobuf
+```proto
 // reclamation_window is the reclamation window duration the provider offers.
 // If the order requires reclamation, this must be >= the order's min_window.
 // Nil means the provider does not offer reclamation on this bid.
@@ -288,7 +288,7 @@ google.protobuf.Duration reclamation_window = 5 [
 
 Add to `Bid`:
 
-```protobuf
+```proto
 // reclamation_window is the reclamation window offered by this provider.
 google.protobuf.Duration reclamation_window = 6 [
   (gogoproto.nullable)    = true,
@@ -302,7 +302,7 @@ google.protobuf.Duration reclamation_window = 6 [
 
 Add to `Order`:
 
-```protobuf
+```proto
 // reclamation is the deployment-level reclamation requirement, propagated to the order.
 // Nil means the deployment does not require reclamation.
 akash.market.v1.DeploymentReclamation reclamation = 5 [
@@ -316,7 +316,7 @@ akash.market.v1.DeploymentReclamation reclamation = 5 [
 
 Add:
 
-```protobuf
+```proto
 // min_reclamation_window is the minimum reclamation window duration allowed.
 google.protobuf.Duration min_reclamation_window = 4 [
   (gogoproto.nullable)    = false,
@@ -338,7 +338,7 @@ google.protobuf.Duration max_reclamation_window = 5 [
 
 Add to `MsgCreateDeployment`:
 
-```protobuf
+```proto
 // reclamation specifies the deployment-level reclamation requirements.
 // Nil means the tenant does not require reclamation.
 akash.market.v1.DeploymentReclamation reclamation = 5 [
@@ -352,7 +352,7 @@ akash.market.v1.DeploymentReclamation reclamation = 5 [
 
 Add to `Deployment`:
 
-```protobuf
+```proto
 // reclamation stores the deployment's reclamation requirements for persistence.
 // Needed so that StartGroup can propagate reclamation to newly created orders.
 akash.market.v1.DeploymentReclamation reclamation = 5 [

--- a/src/content/aeps/aep-86/IMPLEMENTATION.md
+++ b/src/content/aeps/aep-86/IMPLEMENTATION.md
@@ -234,7 +234,7 @@ if len(verReq.RequiredAuditors) > 0 {
 
 The `PlacementRequirements` in the deployment module gains a new field:
 
-```protobuf
+```proto
 // In deployment proto -- PlacementRequirements
 message PlacementRequirements {
     // ... existing attribute fields ...
@@ -260,7 +260,7 @@ Complete proto file specifications for `akash.verification.v1`. All files are pl
 
 ### 4.1 types.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -391,7 +391,7 @@ enum CapabilityFlag {
 
 ### 4.2 state.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -489,7 +489,7 @@ message ProviderSnapshotRecord {
 
 ### 4.3 params.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -603,7 +603,7 @@ message Params {
 
 ### 4.4 msg.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -783,7 +783,7 @@ message MsgUpdateParamsResponse {}
 
 ### 4.5 service.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -817,7 +817,7 @@ service Msg {
 
 ### 4.6 query.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -948,7 +948,7 @@ message QueryParamsResponse {
 
 ### 4.7 events.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1099,7 +1099,7 @@ message EventFeeReturnedToProvider {
 
 ### 4.8 genesis.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1209,7 +1209,7 @@ AMD ROCm SMI), the binary may dynamically load them at runtime:
 
 The Inventory Service is exposed as a gRPC service on the existing provider daemon endpoint:
 
-```protobuf
+```proto
 service InventoryService {
     rpc GetInventorySnapshot(GetInventorySnapshotRequest) returns (GetInventorySnapshotResponse);
 }


### PR DESCRIPTION
## Summary
- replace unsupported `protobuf` code fences with Shiki-supported `proto` fences in AEP documents
- silence the repeated docs-build highlighter warnings without changing code samples

## Verification
- verified Shiki supports the `proto` language id
- searched `src/content/aeps` for remaining ` ```protobuf` fences
- ran `git diff --check`