### PR TITLE
docs: fix Mainnet 14 resource link

### DIFF
--- a/src/content/Blog/akash-mainnet-14-the-core-overhaul-that-changes-everything/index.md
+++ b/src/content/Blog/akash-mainnet-14-the-core-overhaul-that-changes-everything/index.md
@@ -64,6 +64,6 @@ The upgrade to Cosmos SDK v0.53 isn't just another version step, it's the archit
 
 ## Upgrade Resources
 
-If you're an operator, validator, or contributor, please review the upgrade guide here:
+If you're an operator, validator, or contributor, please review the on-chain upgrade proposal:
 
-👉 [Akash Mainnet 14 Node Upgrade Guide](/docs/mainnet-14-upgrade/node-upgrade-guide/)
+👉 [Akash Mainnet 14 Proposal #308](https://www.mintscan.io/akash/proposals/308/)


### PR DESCRIPTION
## Summary
- replace the 404 Mainnet 14 upgrade-guide URL with the live on-chain Proposal #308 page
- update the surrounding wording so the linked resource is described accurately

## Verification
- confirmed the existing `/docs/mainnet-14-upgrade/node-upgrade-guide/` URL returns 404
- confirmed `https://www.mintscan.io/akash/proposals/308/` returns 200
- ran `git diff --check`