### PR TITLE
docs: fix AEP internal links

### DIFF
--- a/src/content/aeps/aep-1/README.md
+++ b/src/content/aeps/aep-1/README.md
@@ -76,7 +76,7 @@ Each status change is requested by the AEP author and reviewed by the AEP editor
 * **Draft** -- Once the first Draft has been merged, you may submit follow-up pull requests with further changes to your Draft until you believe the AEP to be mature and ready to proceed to the next status. An AEP in draft status must be implemented to be considered for promotion to the next status (ignore this requirement for core AEPs).
   * :arrow_right: Last Call -- If agreeable, the AEP editor will assign Last Call status and set a review end date (`review-period-end`), normally 14 days later.
   * :x: Last Call -- A request for Last Call status will be denied if material changes are still expected to be made to the Draft. We hope that AEPs only enter Last Call once, so as to avoid unnecessary noise on the RSS feed.
-* **Last Call** -- This AEP will be listed prominently on the https://aeps.akash.network/ website (subscribe via RSS at [last-call.xml](/last-call.xml)).
+* **Last Call** -- This AEP will be listed prominently on the [Akash roadmap](/roadmap/).
   * :x: -- The Last Call, which results in material changes or substantial unaddressed technical complaints, will cause the AEP to revert to Draft.
   * :arrow_right: Accepted (Core AEPs only) -- A successful Last Call without material changes or unaddressed technical complaints will become Accepted.
   * :arrow_right: Final (Non-Core AEPs) -- A successful Last Call without material changes or unaddressed technical complaints will become Final.

--- a/src/content/aeps/aep-3/README.md
+++ b/src/content/aeps/aep-3/README.md
@@ -26,7 +26,7 @@ A complete deployment has the following sections:
 - [profiles](#profiles)
 - [deployment](#deployment)
 
-A full example deployment configuration can be found [here](deployment.yml).
+Current deployment examples can be found in the [SDL examples library](/docs/developers/deployment/akash-sdl/examples-library).
 
 ### version
 

--- a/src/content/aeps/aep-4/README.md
+++ b/src/content/aeps/aep-4/README.md
@@ -12,7 +12,7 @@ roadmap: major
 
 ## Summary
 
-Launch Testnet with a fully functioning spot computing marketplace for containers and serverless deployment platform as proposed in the [AEP-2](/spec/aep-2). Incentivize user adoption of by applying game mechanics.
+Launch Testnet with a fully functioning spot computing marketplace for containers and serverless deployment platform as proposed in [AEP-2](/roadmap/aep-2/). Incentivize user adoption of by applying game mechanics.
 
 ## Motivation
 
@@ -28,8 +28,8 @@ Decentralized Computing is a novel concept that mandates user behavior change to
 
 - Codename: Alpha
 - Includes DCSs:
-  - [AEP-2: Decentralized Cloud Exchange](/spec/aep-2)
-  - [AEP-3: Stack Definition Language](/spec/aep-3)
+  - [AEP-2: Decentralized Cloud Exchange](/roadmap/aep-2/)
+  - [AEP-3: Stack Definition Language](/roadmap/aep-3/)
 - Token Allocation: 2,000,000 AKT
 - Limit: 100 Members
 - Program(s): Akash Founder Member Rewards


### PR DESCRIPTION
## Summary
- replace stale AEP `/spec/aep-*` links with current `/roadmap/aep-*` routes
- remove a non-existent `last-call.xml` RSS link from AEP-1
- replace AEP-3’s missing `deployment.yml` link with the current SDL examples library

## Verification
- confirmed the generated site has `/roadmap/aep-2/` and `/roadmap/aep-3/` pages
- confirmed the referenced `deployment.yml` is absent from both this site and the archived Akash AEP source
- searched AEP content for remaining `/spec/aep-*`, `/last-call.xml`, and `deployment.yml` refs
- ran `git diff --check`