### PR TITLE
docs: update AEP YAML link

### DIFF
--- a/src/content/aeps/aep-3/README.md
+++ b/src/content/aeps/aep-3/README.md
@@ -17,7 +17,7 @@ Stack Definition Language
 
 ## Specification
 
-Deployment services, datacenters, pricing, etc.. are described by a [YAML](http://www.yaml.org/start.html) configuration file. Configuration files may end in `.yml` or `.yaml`.
+Deployment services, datacenters, pricing, etc.. are described by a [YAML](https://yaml.org/spec/) configuration file. Configuration files may end in `.yml` or `.yaml`.
 
 A complete deployment has the following sections:
 


### PR DESCRIPTION
## Summary
- update the AEP-3 YAML reference from the dead `www.yaml.org/start.html` URL to the current YAML spec page

## Verification
- `curl -L -I http://www.yaml.org/start.html` returns 404
- `curl -L -I https://yaml.org/spec/` returns 200
- `git diff --check`