### PR TITLE
docs: fix AEP support link

### DIFF
--- a/src/content/aeps/aep-4/README.md
+++ b/src/content/aeps/aep-4/README.md
@@ -33,7 +33,7 @@ Decentralized Computing is a novel concept that mandates user behavior change to
 - Token Allocation: 2,000,000 AKT
 - Limit: 100 Members
 - Program(s): Akash Founder Member Rewards
-- Support: [Akash Techinical Chat](https://akash.network/chat)
+- Support: [Akash Technical Chat](https://discord.akash.network)
 
 ### Akash Founder Member Challenge
 


### PR DESCRIPTION
## Summary
- replace the dead AEP-4 `akash.network/chat` support link with the current Akash Discord shortlink
- fix the typo in `Technical` while touching the same support line

## Verification
- `curl -L -I https://akash.network/chat` returns 404
- `curl -L -I https://discord.akash.network` returns 200 and resolves to the Akash Discord invite
- `git diff --check`