### PR TITLE
docs: fix AEP announcement link

### DIFF
--- a/src/content/aeps/aep-4/README.md
+++ b/src/content/aeps/aep-4/README.md
@@ -50,7 +50,7 @@ Decentralized Computing is a novel concept that mandates user behavior change to
 - Developers: 68. [Proof](https://github.com/ovrclk/ecosystem/graphs/contributors).
 - Providers: 144. [Proof](https://akash.vitwit.com).
 
-## Annoucements
+## Announcements
 
 - [Become an Akash Founding Member and Earn Token Rewards](https://akash.network/blog/become-and-akash-founding-member-and-earn-token-rewards/)
 - [Earn 1,000 Tokens and the Akash Founder Level 2 Badge!](https://akash.network/blog/earn-1000-tokens-and-the-akash-founder-level-2-badge/)

--- a/src/content/aeps/aep-4/README.md
+++ b/src/content/aeps/aep-4/README.md
@@ -54,6 +54,6 @@ Decentralized Computing is a novel concept that mandates user behavior change to
 
 - [Become an Akash Founding Member and Earn Token Rewards](https://akash.network/blog/become-and-akash-founding-member-and-earn-token-rewards/)
 - [Earn 1,000 Tokens and the Akash Founder Level 2 Badge!](https://akash.network/blog/earn-1000-tokens-and-the-akash-founder-level-2-badge/)
-- [Announcing Our Third Founding Member Challenge!](https://akash.network/blog/announcing-our-third-founding-member-challenge-earn-2000-akash-tokens/)
+- [Announcing Our Third Founding Member Challenge!](https://akash.network/blog/announcing-our-third-founding-member-challenge/)
 - [Congratulations to Founding Member Challenge Contributors! Still Time to Join for 5500 Akash Tokens!](https://akash.network/blog/congratulations-to-founding-member-challenge-contributors-still-time-to-join-for-5500-akash-tokens)
 - [Announcing Our Founding Member Challenge Winners & Leaderboard!](https://akash.network/blog/announcing-our-founding-member-challenge-winners-leaderboard)


### PR DESCRIPTION
## Summary
- update the AEP-4 announcement link to the existing Akash blog slug for the same article
- fix the misspelled `Annoucements` heading in the same AEP announcement section

## Verification
- `curl -L -I https://akash.network/blog/announcing-our-third-founding-member-challenge-earn-2000-akash-tokens/` returns 404
- `curl -L -I https://akash.network/blog/announcing-our-third-founding-member-challenge/` returns 200
- confirmed the local blog source exists at `src/content/Blog/announcing-our-third-founding-member-challenge/index.md` with the matching title
- searched AEP-4 for the old `Annoucements` spelling
- `git diff --check`