### PR TITLE
docs: remove dead certificate renewal link

### DIFF
--- a/src/content/Docs/providers/operations/updates-maintenance/index.md
+++ b/src/content/Docs/providers/operations/updates-maintenance/index.md
@@ -41,7 +41,6 @@ kubectl -n akash-services scale statefulsets akash-provider --replicas=1
 
 **References:**
 - [Kubernetes Certificate Management](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/)
-- [Manual Certificate Renewal Guide](https://www.txconsole.com/posts/how-to-renew-certificate-manually-in-kubernetes)
 
 When Kubernetes certificates expire, cluster access will fail with `Unauthorized` errors. Rotate certificates proactively to avoid downtime.
 
@@ -141,4 +140,3 @@ If you have a HA cluster, repeat Steps 1-4 on each additional control plane node
 - [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation)
 - [Kubernetes Setup](/docs/providers/setup-and-installation/kubespray/kubernetes-setup)
 - [Provider Verification](/docs/providers/operations/provider-verification)
-


### PR DESCRIPTION
## Summary
- remove a 404 third-party manual certificate renewal link from the provider maintenance docs
- keep the official Kubernetes kubeadm certificate management reference, which covers certificate expiration checks and manual renewal

## Verification
- `curl -L -I https://www.txconsole.com/posts/how-to-renew-certificate-manually-in-kubernetes` returns 404
- `curl -L -I https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/` returns 200
- checked the Kubernetes page contains the certificate expiration and manual renewal sections used by this Akash guide
- `git diff --check`