### PR TITLE
docs: fix awesome-akash example download

### DIFF
--- a/src/content/Docs/developers/deployment/akash-sdl/examples-library/index.md
+++ b/src/content/Docs/developers/deployment/akash-sdl/examples-library/index.md
@@ -241,7 +241,7 @@ Use the [Table of Contents](https://github.com/akash-network/awesome-akash#table
 git clone https://github.com/akash-network/awesome-akash.git
 
 # Or download a specific example
-wget https://raw.githubusercontent.com/akash-network/awesome-akash/master/nginx/deploy.yaml
+wget https://raw.githubusercontent.com/akash-network/awesome-akash/master/gitea/deploy.yaml
 ```
 
 ### 4. Read the Instructions


### PR DESCRIPTION
## Summary
- update the SDL examples library download command from a removed `nginx/deploy.yaml` example to an existing `gitea/deploy.yaml` example

## Verification
- `curl -L -I https://raw.githubusercontent.com/akash-network/awesome-akash/master/nginx/deploy.yaml` returns 404
- `curl -L -I https://raw.githubusercontent.com/akash-network/awesome-akash/master/gitea/deploy.yaml` returns 200
- confirmed `Gitea` is listed in the current `awesome-akash` README table of contents
- `git diff --check`