### PR TITLE
docs: fix AEP stable payments link

### DIFF
--- a/src/content/aeps/aep-76/README.md
+++ b/src/content/aeps/aep-76/README.md
@@ -153,7 +153,7 @@ When an invoice for A ACT is due, the protocol:
 #### `x/market` Leases & settlement
 * Quotes remain **USD‑first** in the UI; on chain, settlement pays providers **in AKT** by consuming ACT.  
 * Providers optionally auto‑stake a % of payouts (off by default).
-* AEP‑23 brought [stable payments](https://akash.network/docs/deployments/stable-payment-deployments) and take‑rates; with BME we keep the stable UX but remove take‑rates and settle AKT‑only.*
+* AEP‑23 brought [stable payments](/roadmap/aep-23/) and take‑rates; with BME we keep the stable UX but remove take‑rates and settle AKT‑only.*
 
 ##### Settlement loop (system flow)
 


### PR DESCRIPTION
## Summary
- update AEP-76’s stable payments reference from a removed docs URL to the current AEP-23 roadmap page

## Verification
- `curl -L -I https://akash.network/docs/deployments/stable-payment-deployments` returns 404
- `curl -L -I https://akash.network/roadmap/aep-23/` returns 200
- confirmed AEP-23 is titled `Multi Currency Support with Stable Payments` in the local source
- `git diff --check`