### PR TITLE
docs: fix AEP reference link

### DIFF
--- a/src/content/aeps/aep-42/README.md
+++ b/src/content/aeps/aep-42/README.md
@@ -17,4 +17,4 @@ Being able to store logs on Akash (or other decentralized storage) reduces cost 
 
 ## Summary
 
-While [AEP-34](https://github.com/ovrclk/aeps/tree/main/spec/aep-34) will address the pressing need for tenant/ workload logs it will do so by utilizing centralized logging setvices provided as SaaS. The scope of this AEP is to find a way to store logs relatively inexpensively on Akash or dedicated decentralized storage networks (like StorJ or Filecoin) while ensuring that the Akash user experience does not suffer significantly in doing so.
+While [AEP-34](/roadmap/aep-34/) will address the pressing need for tenant/ workload logs it will do so by utilizing centralized logging setvices provided as SaaS. The scope of this AEP is to find a way to store logs relatively inexpensively on Akash or dedicated decentralized storage networks (like StorJ or Filecoin) while ensuring that the Akash user experience does not suffer significantly in doing so.

--- a/src/content/aeps/aep-42/README.md
+++ b/src/content/aeps/aep-42/README.md
@@ -17,4 +17,4 @@ Being able to store logs on Akash (or other decentralized storage) reduces cost 
 
 ## Summary
 
-While [AEP-34](/roadmap/aep-34/) will address the pressing need for tenant/ workload logs it will do so by utilizing centralized logging setvices provided as SaaS. The scope of this AEP is to find a way to store logs relatively inexpensively on Akash or dedicated decentralized storage networks (like StorJ or Filecoin) while ensuring that the Akash user experience does not suffer significantly in doing so.
+While [AEP-34](/roadmap/aep-34/) will address the pressing need for tenant/ workload logs it will do so by utilizing centralized logging services provided as SaaS. The scope of this AEP is to find a way to store logs relatively inexpensively on Akash or dedicated decentralized storage networks (like StorJ or Filecoin) while ensuring that the Akash user experience does not suffer significantly in doing so.


### PR DESCRIPTION
## Summary
- update AEP-42’s AEP-34 reference from a dead old GitHub organization path to the current roadmap page
- fix `setvices` -> `services` on the same summary line

## Verification
- `curl -L -I https://github.com/ovrclk/aeps/tree/main/spec/aep-34` returns 404
- `curl -L -I https://akash.network/roadmap/aep-34/` returns 200
- confirmed local AEP-34 source exists and is titled `Workload Log Forwarding via Akash Console`
- searched AEP-42 for the old `setvices` spelling
- `git diff --check`