### PR TITLE
docs: fix AEP source links

### DIFF
--- a/src/content/aeps/aep-56/README.md
+++ b/src/content/aeps/aep-56/README.md
@@ -33,9 +33,9 @@ Investigate and implement chain SDK which supports:
 
 Additionally, this SDK should have:
 * certificates manager and corresponding utils (https://github.com/akash-network/akashjs/blob/main/src/certificates/certificate-manager/CertificateManager.ts)
-* certificate validation logic for provider nodes https://github.com/akash-network/console/blob/main/apps/provider-proxy/src/services/CertificateValidator.ts
+* certificate validation logic for provider nodes https://github.com/akash-network/console/blob/main/apps/provider-proxy/src/services/CertificateValidator/CertificateValidator.ts
 * SDL related logic
-  - move from https://github.com/akash-network/akashjs/blob/main/src/sdl/SDL/SDL.ts
+  - move from https://github.com/akash-network/akashjs/blob/main/src/sdl/index.ts
   - move from https://github.com/akash-network/console/tree/main/apps/deploy-web/src/utils/sdl
   - we implemented SDL import from yaml and generator from object to yaml. The generator will have to be re-designed because it currently received an object of the type of the SDL builder form, which is not technically 1:1 with the SDL spec.
 


### PR DESCRIPTION
## Summary
- update AEP-56 source references for the Console certificate validator and akashjs SDL module to their current paths

## Verification
- old Console `CertificateValidator.ts` URL returns 404; current nested `CertificateValidator/CertificateValidator.ts` URL returns 200
- old akashjs `src/sdl/SDL/SDL.ts` URL returns 404; current `src/sdl/index.ts` URL returns 200
- `git diff --check`