### PR TITLE
docs: fix Cosmos SDK module links

### DIFF
--- a/src/content/aeps/aep-22/README.md
+++ b/src/content/aeps/aep-22/README.md
@@ -72,7 +72,7 @@ There are numerous ways to subsidize providers, some considerations are:
 
 We propose a portion of the Tokens from the `Incentive Distribution Pool` be allocated to the Public Goods Fund to incentivize the growth of the Akash Network. The Public Goods Fund is a pool of AKT that is distributed to developers who build applications that grow the Akash Network and its adoption. The Developer Fund is distributed through on-chain governance.
 
-The mechanism for distributing the Developer Fund will be determined by the [Steering Committee][streeing-committee].
+The mechanism for distributing the Developer Fund will be determined by the [Steering Committee][steering-committee].
 
 ### Stakers
 
@@ -119,7 +119,7 @@ $F_p = \digamma_0 \cdot (1 - R_t \cdot (1 - R_d))$
 [akt-economics-1]: https://ipfs.io/ipfs/QmdV52bF7j4utynJ6L11RgG93FuJiUmBH1i7pRD6NjUt6B
 [cosmos-sdk-x-mint]: https://docs.cosmos.network/sdk/latest/modules/mint/README
 [osmosis]: https://osmosis.zone/
-[streeing-committee]: https://github.com/akash-network/community/tree/main/committee-steering
+[steering-committee]: https://github.com/akash-network/community/tree/main/committee-steering
 [sig-economics]: https://github.com/akash-network/community/tree/main/sig-economics
 [akt-evolution]: https://akash.network/blog/an-evolution-of-akash-network-token-economics/
 [filecoin-plus]: https://docs.filecoin.io/store/filecoin-plus/overview/

--- a/src/content/aeps/aep-22/README.md
+++ b/src/content/aeps/aep-22/README.md
@@ -117,7 +117,7 @@ The fees on the order offered to the Provider is $F_p = \digamma_0 - F_t$ , or:
 $F_p = \digamma_0 \cdot (1 - R_t \cdot (1 - R_d))$
 
 [akt-economics-1]: https://ipfs.io/ipfs/QmdV52bF7j4utynJ6L11RgG93FuJiUmBH1i7pRD6NjUt6B
-[cosmos-sdk-x-mint]: https://docs.cosmos.network/main/modules/mint
+[cosmos-sdk-x-mint]: https://docs.cosmos.network/sdk/latest/modules/mint/README
 [osmosis]: https://osmosis.zone/
 [streeing-committee]: https://github.com/akash-network/community/tree/main/committee-steering
 [sig-economics]: https://github.com/akash-network/community/tree/main/sig-economics
@@ -126,4 +126,4 @@ $F_p = \digamma_0 \cdot (1 - R_t \cdot (1 - R_d))$
 
 ## Copyright
 
-All content herein is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). 
+All content herein is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/src/content/aeps/aep-76/README.md
+++ b/src/content/aeps/aep-76/README.md
@@ -438,7 +438,7 @@ MsgBurnACT {
 
 * `RemintCredits >= 0` except during a price‑crash path when circuit breaker logic governs shortfall; if `RemintCredits < 0`, only inflationary mint covers the difference (visible metric).
 
-*(Cosmos SDK’s [bank/mint](https://docs.cosmos.network/v0.46/modules/bank/) facilities support this pattern cleanly)*
+*(Cosmos SDK’s [bank/mint](https://docs.cosmos.network/sdk/latest/modules/bank/README) facilities support this pattern cleanly)*
 
 ### Provider & Tenant UX
 
@@ -469,7 +469,7 @@ MsgBurnACT {
 
 * **Oracle manipulation:** use multi‑feed medianization with [TWAP](https://docs.osmosis.zone/overview/features/concentrated-liquidity); cap per‑block price move; pausable by governance multisig in emergencies. 
 * **Liquidity stress:** perform console buys via RFQ/aggregator (Osmosis primary) with max slippage. (Osmosis as Cosmos liquidity hub. 
-* **Module integrity:** [bank](https://docs.cosmos.network/v0.46/modules/bank) burn/mint auditing with supply invariants in end blockers. 
+* **Module integrity:** [bank](https://docs.cosmos.network/sdk/latest/modules/bank/README) burn/mint auditing with supply invariants in end blockers.
 
 ### Rollout plan
 

--- a/src/content/aeps/aep-80/README.md
+++ b/src/content/aeps/aep-80/README.md
@@ -502,7 +502,7 @@ This is a new module with no existing state to migrate. It does not modify any e
 ## References
 
 - [AEP-76: Burn Mint Equilibrium](../aep-76)
-- [Cosmos SDK Bank Module](https://docs.cosmos.network/v0.46/modules/bank/)
+- [Cosmos SDK Bank Module](https://docs.cosmos.network/sdk/latest/modules/bank/README)
 - [CosmWasm Documentation](https://docs.cosmwasm.com/)
 
 ## Copyright


### PR DESCRIPTION
## Summary
- update dead Cosmos SDK mint and bank module documentation links in AEP references to the current official Cosmos SDK module pages
- fix a misspelled `streeing-committee` reference label in AEP-22

## Verification
- `curl -L -I https://docs.cosmos.network/main/modules/mint` returns 404
- `curl -L -I https://docs.cosmos.network/v0.46/modules/bank/` returns 404
- `curl -L -I https://docs.cosmos.network/sdk/latest/modules/mint/README` returns 200
- `curl -L -I https://docs.cosmos.network/sdk/latest/modules/bank/README` returns 200
- searched AEP-22 for the old `streeing` spelling
- `git diff --check`