### PR TITLE
docs: fix AEP paper link

### DIFF
--- a/src/content/aeps/aep-5/README.md
+++ b/src/content/aeps/aep-5/README.md
@@ -20,7 +20,7 @@ Akash is a marketplace for cloud compute resources which is designed to reduce w
 
 ## Detailed Proposal
 
-Detailed proposal is publised in the [paper](https://github.com/akash-network/AEP/blob/main/spec/aep-2/economics.pdf)
+Detailed proposal is published in the [paper](https://github.com/akash-network/AEP/blob/main/spec/aep-5/economics.pdf)
 
 ## References
 


### PR DESCRIPTION
## Summary
- update AEP-5’s economics paper link from the nonexistent AEP-2 PDF path to the existing AEP-5 PDF
- fix a typo in the same sentence (`publised` -> `published`)

## Verification
- `curl -L -I https://github.com/akash-network/AEP/blob/main/spec/aep-2/economics.pdf` returns 404
- `curl -L -I https://github.com/akash-network/AEP/blob/main/spec/aep-5/economics.pdf` returns 200
- confirmed the local AEP-5 PDF exists at `src/content/aeps/aep-5/economics.pdf`
- `git diff --check`