### PR TITLE
docs: fix AEP alert typos

### DIFF
--- a/src/content/aeps/aep-71/README.md
+++ b/src/content/aeps/aep-71/README.md
@@ -14,10 +14,10 @@ roadmap: minor
 
 ## Motivation
 
-A users deployment can close becaause of reasons besides running out of funds (which is addressed as part of aep-33). This second type of Alert and Notification lets the user know immediately when a deployment is closed for any reason.
+A user's deployment can close because of reasons besides running out of funds (which is addressed as part of aep-33). This second type of Alert and Notification lets the user know immediately when a deployment is closed for any reason.
 
 ## Summary
 
-Users of Akash Console will have the option of configuring a "Deployment Closed" alert for any deployment within their account and optionally tieing the alert to a notification channel. The initial notification channel supported will be email with more notification channels added over time, based on customer/ user feedback. 
+Users of Akash Console will have the option of configuring a "Deployment Closed" alert for any deployment within their account and optionally tying the alert to a notification channel. The initial notification channel supported will be email with more notification channels added over time, based on customer/ user feedback.
 
 Github Milestone: https://github.com/akash-network/console/milestone/23


### PR DESCRIPTION
## Summary
- fix typos in AEP-71 (`A users`, `becaause`, `tieing`)

## Verification
- searched the touched AEP for the old misspellings
- `git diff --check`