### PR TITLE
docs: fix AEP connection typos

### DIFF
--- a/src/content/aeps/aep-2/README.md
+++ b/src/content/aeps/aep-2/README.md
@@ -384,15 +384,15 @@ A _deployment_ represents the _current state_ of a stack as fulfilled by the Aka
 | container   | Docker container                                     |
 | compute     | [resources](#computeunit) needed for each instance   |
 | count       | number of instances to run                           |
-| connections | List of allowed incomming [connections](#connection) |
+| connections | List of allowed incoming [connections](#connection) |
 
 #### Connection
 
 | Field      | Description                                                                |
 | ---------- | -------------------------------------------------------------------------- |
 | port       | TCP port                                                                   |
-| workload   | [Workload](#workload) name to allow incomming connection from              |
-| datacenter | [Datacenter](#deploymentinfrastructure) to allow incomming connection from |
+| workload   | [Workload](#workload) name to allow incoming connection from               |
+| datacenter | [Datacenter](#deploymentinfrastructure) to allow incoming connection from  |
 | global     | If `true`, allow all connections, regardless of source                     |
 
 #### LeasedWorkload


### PR DESCRIPTION
## Summary
- fix repeated `incomming` misspellings in AEP-2's workload and connection tables

## Verification
- confirmed the old misspellings were present in src/content/aeps/aep-2/README.md on the current audit stack
- confirmed no existing open PR from this fork targets AEP-2 typo fixes
- ran git diff --check
- ran rg for the old typo in AEP-2