### PR TITLE
docs: fix AEP MultiZone link

### DIFF
--- a/src/content/aeps/aep-12/README.md
+++ b/src/content/aeps/aep-12/README.md
@@ -39,7 +39,7 @@ TEE is platform-dependent, all major providers have a form for TEE implementatio
 * Intel
   * [SGX Software Guard Extensions](https://01.org/intel-softwareguard-extensions)
 * RISC-V
-  * [MultiZone™ Security Trusted Execution Environment](https://hex-five.com/multizone-security-sdk/)
+  * [MultiZone™ Security Trusted Execution Environment](https://github.com/hex-five/multizone-iot-sdk)
 * IBM
   * [IBM Secure Service Container](https://www.ibm.com/us-en/marketplace/secure-service-container)
 


### PR DESCRIPTION
## Summary
- replace AEP-12's stale Hex Five MultiZone product URL with the active MultiZone IoT SDK repository for RISC-V

## Verification
- confirmed https://hex-five.com/multizone-security-sdk/ returns 404
- confirmed https://github.com/hex-five/multizone-iot-sdk returns 200 and describes MultiZone for RISC-V processors
- ran git diff --check