### PR TITLE
docs: replace dead Forbole RPC endpoint

### DIFF
--- a/src/content/Docs/developers/deployment/cli/installation-guide/index.mdx
+++ b/src/content/Docs/developers/deployment/cli/installation-guide/index.mdx
@@ -385,7 +385,7 @@ export AKASH_GAS_PRICES=0.05uakt
 If the default RPC node is down, try an alternative:
 
 ```bash
-export AKASH_NODE=https://rpc.akash.forbole.com:443
+export AKASH_NODE=https://rpc.akt.dev/rpc
 # or
 export AKASH_NODE=https://akash-rpc.polkachu.com:443
 ```

--- a/src/content/Docs/node-operators/architecture/api-layer/index.mdx
+++ b/src/content/Docs/node-operators/architecture/api-layer/index.mdx
@@ -1306,7 +1306,7 @@ ufw allow from 1.2.3.4 to any port 1317
 
 ```
 https://rpc.akashnet.net:443
-https://rpc.akash.forbole.com:443
+https://rpc.akt.dev/rpc
 https://rpc-akash.ecostake.com:443
 https://akash-rpc.polkachu.com:443
 https://akash.c29r3.xyz:443/rpc
@@ -1346,4 +1346,3 @@ http://localhost:1317/swagger/
 - [Cosmos SDK gRPC Docs](https://docs.cosmos.network/sdk/v0.53/learn/advanced/grpc_rest)
 - [Akash API Repository](https://github.com/akash-network/akash-api)
 - [Protocol Buffer Definitions](https://buf.build/akash-network)
-


### PR DESCRIPTION
## Summary
- replace the dead Forbole RPC example with the live akt.dev RPC endpoint from Akash mainnet metadata
- update both the CLI troubleshooting guide and API-layer endpoint example list

## Verification
- confirmed https://rpc.akash.forbole.com:443 redirects to https://rpc.forbole.com/ and returns 404
- confirmed https://rpc.akt.dev/rpc returns 200
- confirmed https://rpc.akt.dev/rpc is listed in https://raw.githubusercontent.com/akash-network/net/main/mainnet/meta.json
- ran git diff --check