### PR TITLE
docs: fix Wormhole guardian set command

### DIFF
--- a/src/content/Docs/node-operators/hermes-relayer/index.md
+++ b/src/content/Docs/node-operators/hermes-relayer/index.md
@@ -237,8 +237,11 @@ The Wormhole contract's guardian set is behind the current mainnet guardian set.
 
 To check the current mainnet guardian set index:
 ```bash
-curl -s https://raw.githubusercontent.com/wormhole-foundation/wormhole/main/guardianset/mainnetv2/ \
-  | grep -o 'v[0-9]*\.prototxt' | sort -V | tail -1
+curl -s "https://api.github.com/repos/wormhole-foundation/wormhole/contents/guardianset/mainnetv2/canonical_sets?ref=main" \
+  | grep -o '"name": "v[0-9]*\.prototxt"' \
+  | grep -o 'v[0-9]*\.prototxt' \
+  | sort -V \
+  | tail -1
 ```
 
 ### source ... is not authorized oracle provider


### PR DESCRIPTION
## Summary
- replace the broken raw GitHub directory curl in the Hermes relayer troubleshooting guide
- use the GitHub contents API for Wormhole's current mainnet canonical guardian set files

## Verification
- confirmed the old raw.githubusercontent.com directory URL returns 400
- confirmed the GitHub contents API URL returns 200
- ran the replacement command and confirmed it returns the latest canonical set file, currently v5.prototxt
- ran git diff --check