### PR TITLE
docs: fix Telegram link in token circulation post

### DIFF
--- a/src/content/Blog/ceo-statement-on-total-akt-token-circulation/index.md
+++ b/src/content/Blog/ceo-statement-on-total-akt-token-circulation/index.md
@@ -83,7 +83,7 @@ As I’ve mentioned before, we couldn’t have achieved our Mainnet 1 and BitMax
 
 I’m grateful for your belief in our vision, and for your patience and understanding as we improve our communications efforts.  
 
-I invite you to [join our Telegram](http://t.me/AkashNW(opens in a new tab)) and continue to give us feedback so we can improve our communications, product, and community.
+I invite you to [join our Telegram](https://t.me/AkashNW) and continue to give us feedback so we can improve our communications, product, and community.
 
 ####   
   


### PR DESCRIPTION
## Summary
- Replace a malformed Telegram link in the token circulation blog post with the canonical Akash Telegram URL
- Preserve the existing call-to-action link and add a final newline while touching the file

## Verification
- Confirmed the malformed `http://t.me/AkashNW(opens` URL redirects to Telegram generic landing content instead of the Akash channel
- Confirmed `https://t.me/AkashNW` returns HTTP 200
- Ran `git diff --check`
- Confirmed the old malformed link pattern is no longer present in the post