### PR TITLE
docs: replace stale Forbole RPC endpoint

### DIFF
--- a/src/content/Blog/how-to-mine-pkt-faster-on-the-world-s-first-decentralized-cloud/index.md
+++ b/src/content/Blog/how-to-mine-pkt-faster-on-the-world-s-first-decentralized-cloud/index.md
@@ -179,7 +179,7 @@ akash tx cert create client --chain-id $AKASH_CHAIN_ID --keyring-backend os --fr
 If you see an error adding your certificate to the blockchain, try again! Now to deploy on Akash, run:
 
 ```sh
-akash tx deployment create deploy.yml --from` `**<your_wallet_name>**` `--node https://rpc.akash.forbole.com:443 --chain-id akashnet-2 --fees 5000uakt -y
+akash tx deployment create deploy.yml --from <your_wallet_name> --node https://rpc.akt.dev/rpc --chain-id akashnet-2 --fees 5000uakt -y
 ```
 
 After that command, a string of JSON will appear in your terminal/command prompt.
@@ -287,13 +287,13 @@ akash query deployment get --owner <your_akash_wallet_address> --node=tcp://135.
 Create a market order.
 
 ```sh
-akash query market order get --node=https://rpc.akash.forbole.com:443 --owner <your_akash_wallet> --dseq <your_dseq> --oseq 1 --gseq 1
+akash query market order get --node=https://rpc.akt.dev/rpc --owner <your_akash_wallet> --dseq <your_dseq> --oseq 1 --gseq 1
 ```
 
 Acquire a list of bids.
 
 ```sh
-akash query market bid list --owner=<your_wallet_address> --node=https://rpc.akash.forbole.com:443 --dseq <your_dseq>
+akash query market bid list --owner=<your_wallet_address> --node=https://rpc.akt.dev/rpc --dseq <your_dseq>
 ```
 
 Select a bid from a provider.

--- a/src/content/Docs/developers/deployment/cli/installation-guide/index.mdx
+++ b/src/content/Docs/developers/deployment/cli/installation-guide/index.mdx
@@ -385,7 +385,7 @@ export AKASH_GAS_PRICES=0.05uakt
 If the default RPC node is down, try an alternative:
 
 ```bash
-export AKASH_NODE=https://rpc.akash.forbole.com:443
+export AKASH_NODE=https://rpc.akt.dev/rpc
 # or
 export AKASH_NODE=https://akash-rpc.polkachu.com:443
 ```

--- a/src/content/Docs/node-operators/architecture/api-layer/index.mdx
+++ b/src/content/Docs/node-operators/architecture/api-layer/index.mdx
@@ -1306,7 +1306,7 @@ ufw allow from 1.2.3.4 to any port 1317
 
 ```
 https://rpc.akashnet.net:443
-https://rpc.akash.forbole.com:443
+https://rpc.akt.dev/rpc
 https://rpc-akash.ecostake.com:443
 https://akash-rpc.polkachu.com:443
 https://akash.c29r3.xyz:443/rpc
@@ -1346,4 +1346,3 @@ http://localhost:1317/swagger/
 - [Cosmos SDK gRPC Docs](https://docs.cosmos.network/sdk/v0.53/learn/advanced/grpc_rest)
 - [Akash API Repository](https://github.com/akash-network/akash-api)
 - [Protocol Buffer Definitions](https://buf.build/akash-network)
-


### PR DESCRIPTION
## Summary
- Replace remaining `rpc.akash.forbole.com` examples with the current `https://rpc.akt.dev/rpc` endpoint
- Update the CLI troubleshooting guide and API layer endpoint examples
- Fix the PKT mining post deployment command so the wallet placeholder is valid shell text instead of broken inline Markdown

## Verification
- Confirmed `https://rpc.akash.forbole.com:443/status` redirects to `https://rpc.forbole.com/` and returns HTTP 404
- Confirmed `https://rpc.akt.dev/rpc/status` returns HTTP 200
- Confirmed `https://rpc.akt.dev/rpc` appears in the current `akash-network/net` mainnet metadata
- Ran `git diff --check`
- Confirmed no `rpc.akash.forbole.com` references remain in the touched files