### PR TITLE
docs: replace dead RPC IP endpoint

### DIFF
--- a/src/content/Blog/how-to-mine-pkt-faster-on-the-world-s-first-decentralized-cloud/index.md
+++ b/src/content/Blog/how-to-mine-pkt-faster-on-the-world-s-first-decentralized-cloud/index.md
@@ -281,7 +281,7 @@ Note, if you just followed the Quick Start Guide, you might run into an error su
 Next, run:
 
 ```sh
-akash query deployment get --owner <your_akash_wallet_address> --node=tcp://135.181.60.250:26657 --dseq <your_dseq>
+akash query deployment get --owner <your_akash_wallet_address> --node=https://rpc.akt.dev/rpc --dseq <your_dseq>
 ```
 
 Create a market order.
@@ -299,25 +299,25 @@ akash query market bid list --owner=<your_wallet_address> --node=https://rpc.aka
 Select a bid from a provider.
 
 ```sh
-akash tx market lease create --chain-id akashnet-2 --node=tcp://135.181.60.250:26657 --owner <your_wallet_address> --dseq <your_dseq> --gseq 1 --oseq 1 --provider <select_a_provider_from_the_list> --from <your_wallet_name> --fees 5000uakt
+akash tx market lease create --chain-id akashnet-2 --node=https://rpc.akt.dev/rpc --owner <your_wallet_address> --dseq <your_dseq> --gseq 1 --oseq 1 --provider <select_a_provider_from_the_list> --from <your_wallet_name> --fees 5000uakt
 ```
 
 Confirm your lease is open.
 
 ```sh
-akash query market lease list --owner <your_wallet_address> --node=tcp://135.181.60.250:26657 --dseq <your_dseq>
+akash query market lease list --owner <your_wallet_address> --node=https://rpc.akt.dev/rpc --dseq <your_dseq>
 ```
 
 Send the manifest.
 
 ```sh
-akash provider send-manifest deploy.yml --node=tcp://135.181.60.250:26657 --dseq <your_dseq> --provider <the_provider_you_selected> --home ~/.akash --from <your_wallet_address>
+akash provider send-manifest deploy.yml --node=https://rpc.akt.dev/rpc --dseq <your_dseq> --provider <the_provider_you_selected> --home ~/.akash --from <your_wallet_address>
 ```
 
 Ensure the miner is running by looking at your logs.
 
 ```sh
-akash provider lease-logs --node=tcp://135.181.60.250:26657  --dseq <your_dseq> --gseq 1 --oseq 1 --provider <the_provider_you_selected> --from <your_wallet_address>
+akash provider lease-logs --node=https://rpc.akt.dev/rpc --dseq <your_dseq> --gseq 1 --oseq 1 --provider <the_provider_you_selected> --from <your_wallet_address>
 ```
 
 Another great way to see how much PKT you are mining is by visiting the [block explorer](https://explorer.pkt.cash) and inputting your PKT wallet address.

--- a/src/content/Docs/developers/deployment/cli/installation-guide/index.mdx
+++ b/src/content/Docs/developers/deployment/cli/installation-guide/index.mdx
@@ -247,7 +247,7 @@ echo $AKASH_NODE $AKASH_CHAIN_ID $AKASH_KEYRING_BACKEND
 
 You should see something similar to:
 
-`http://135.181.60.250:26657 akashnet-2 os`
+`https://rpc.akt.dev/rpc akashnet-2 os`
 
 ### Set Additional Environment Variables
 


### PR DESCRIPTION
## Summary
- Replace the nonresponsive `135.181.60.250:26657` RPC example in the CLI installation guide
- Update PKT mining commands that still point at the same dead raw IP endpoint
- Remove a hidden nonbreaking space from the lease logs command while replacing the endpoint

## Verification
- Confirmed `http://135.181.60.250:26657/status` times out with an 8-second cap
- Confirmed `https://rpc.akt.dev/rpc/status` returns HTTP 200
- Confirmed `https://rpc.akt.dev/rpc` appears in the current `akash-network/net` mainnet metadata
- Ran `git diff --check`
- Confirmed the dead IP endpoint no longer appears in the touched files