### PR TITLE
docs: fix Helm charts repository link

### DIFF
--- a/src/content/Blog/q2-2022-update-for-akash-roadmap/index.md
+++ b/src/content/Blog/q2-2022-update-for-akash-roadmap/index.md
@@ -101,13 +101,13 @@ Currently, there is an enormous and intricate set of steps that a provider needs
 
 A provider onboarding framework is to ease new providers selling compute on Akash, planned to be released in Q4 of 2021 is now delayed.
 
-The automation for bootstrapping a node is code-complete and tested internally for Testnet and Devnets; the documentation is, however, still pending, so we’re moving this deliverable to next quarter. The helm charts for installing various components are available at [ovrclk/helm-charts](https://github.com/ovrclk/helm-charts).
+The automation for bootstrapping a node is code-complete and tested internally for Testnet and Devnets; the documentation is, however, still pending, so we’re moving this deliverable to next quarter. The helm charts for installing various components are available at [akash-network/helm-charts](https://github.com/akash-network/helm-charts).
 
 **Status**: Incomplete
 
 **Related Repositories:**
 
-- [ovrclk/helm-charts](https://github.com/ovrclk/helm-charts)
+- [akash-network/helm-charts](https://github.com/akash-network/helm-charts)
 
 ### **Developer Hub** 
 


### PR DESCRIPTION
## Summary
- Replace two dead `ovrclk/helm-charts` links in the Q2 2022 roadmap post
- Point readers at the current `akash-network/helm-charts` repository

## Verification
- Confirmed `https://github.com/ovrclk/helm-charts` returns HTTP 404
- Confirmed `https://github.com/akash-network/helm-charts` returns HTTP 200
- Confirmed current provider docs already reference `akash-network/helm-charts`
- Ran `git diff --check`