### PR TITLE
docs: fix AEP source reference links

### DIFF
--- a/src/content/aeps/aep-56/README.md
+++ b/src/content/aeps/aep-56/README.md
@@ -33,9 +33,9 @@ Investigate and implement chain SDK which supports:
 
 Additionally, this SDK should have:
 * certificates manager and corresponding utils (https://github.com/akash-network/akashjs/blob/main/src/certificates/certificate-manager/CertificateManager.ts)
-* certificate validation logic for provider nodes https://github.com/akash-network/console/blob/main/apps/provider-proxy/src/services/CertificateValidator.ts
+* certificate validation logic for provider nodes https://github.com/akash-network/console/blob/main/apps/provider-proxy/src/services/CertificateValidator/CertificateValidator.ts
 * SDL related logic
-  - move from https://github.com/akash-network/akashjs/blob/main/src/sdl/SDL/SDL.ts
+  - move from https://github.com/akash-network/akashjs/blob/main/src/sdl/index.ts
   - move from https://github.com/akash-network/console/tree/main/apps/deploy-web/src/utils/sdl
   - we implemented SDL import from yaml and generator from object to yaml. The generator will have to be re-designed because it currently received an object of the type of the SDL builder form, which is not technically 1:1 with the SDL spec.
 


### PR DESCRIPTION
## Summary
- Update AEP-56 certificate validation source reference to the current Console path
- Update AEP-56 SDL source reference to the current AkashJS path

## Verification
- Confirmed the old Console `CertificateValidator.ts` URL returns HTTP 404
- Confirmed the new Console `CertificateValidator/CertificateValidator.ts` URL returns HTTP 200
- Confirmed the old AkashJS `src/sdl/SDL/SDL.ts` URL returns HTTP 404
- Confirmed the new AkashJS `src/sdl/index.ts` URL returns HTTP 200
- Ran `git diff --check`