### PR TITLE
docs: fix AEP process links

### DIFF
--- a/src/content/aeps/aep-1/README.md
+++ b/src/content/aeps/aep-1/README.md
@@ -99,7 +99,7 @@ Other exceptional statuses include:
 
 Each AEP should have the following parts:
 
-- Preamble - RFC 822 style headers containing metadata about the AEP, including the AEP number, a short descriptive title (limited to a maximum of 44 characters), and the author details. See [below](https://github.com/ovrclk/AEPs/blob/master/AEPSS/aep-1.md#aep-header-preamble) for details.
+- Preamble - RFC 822 style headers containing metadata about the AEP, including the AEP number, a short descriptive title (limited to a maximum of 44 characters), and the author details. See [below](#aep-header-preamble) for details.
 - Abstract - A short (~200 word) description of the technical issue being addressed.
 - Motivation (*optional*) - The motivation is critical for AEPs that want to change the Akash protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the AEP solves. AEP submissions without sufficient motivation may be rejected outright.
 - Specification - The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations Akash platform.
@@ -262,7 +262,7 @@ This document was derived heavily from [Ethereum's EIP-1] written by Martin Becz
 [Ethereum's EIP-1]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md
 [Bitcoin's BIP-0001]: https://github.com/bitcoin/bips
 [Akash Technical Chat]: https://discord.akash.network/
-[Pull request]: https://github.com/ovrclk/AEPs/pulls
+[Pull request]: https://github.com/akash-network/website/pulls
 
 ## Copyright
 


### PR DESCRIPTION
## Summary
- Replace AEP-1 self-reference to the retired `ovrclk/AEPs` repo with a local section anchor
- Update the AEP pull request reference to the current website repository pull requests page

## Verification
- Confirmed the old `ovrclk/AEPs` AEP-1 URL returns HTTP 404
- Confirmed the old `ovrclk/AEPs/pulls` URL returns HTTP 404
- Confirmed `https://github.com/akash-network/website/pulls` returns HTTP 200
- Confirmed the target `AEP Header Preamble` heading exists in the same file
- Ran `git diff --check`