### PR TITLE
docs: add shareable anchor links to docs headings

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,8 @@ import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
 import astroExpressiveCode from "astro-expressive-code";
 import { defineConfig } from "astro/config";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import rehypeSlug from "rehype-slug";
 import remarkDirective from "remark-directive";
 import remarkMath from "remark-math";
 import { customAsidePlugin } from "./src/lib/aside/customAsidePlugin";
@@ -15,6 +17,29 @@ export default defineConfig({
   redirects: redirects,
   markdown: {
     remarkPlugins: [remarkMath, normalizeMath, remarkDirective, mermaid, customAsidePlugin],
+    rehypePlugins: [
+      rehypeSlug,
+      [
+        rehypeAutolinkHeadings,
+        {
+          behavior: "append",
+          properties: {
+            className: ["heading-anchor"],
+            "data-anchor-link": true,
+            ariaLabel: "Link to section",
+          },
+          content: {
+            type: "element",
+            tagName: "span",
+            properties: {
+              className: ["heading-anchor-icon"],
+              ariaHidden: "true",
+            },
+            children: [{ type: "text", value: "#" }],
+          },
+        },
+      ],
+    ],
   },
   integrations: [
     tailwind(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,8 @@
         "react-phone-number-input": "^3.4.10",
         "react-simple-maps": "^3.0.0",
         "react-swipeable": "^7.0.1",
+        "rehype-autolink-headings": "7.1.0",
+        "rehype-slug": "6.0.0",
         "remark-directive": "^3.0.0",
         "remark-math": "^6.0.0",
         "remark-smartypants": "^2.0.0",
@@ -9095,6 +9097,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -9252,6 +9267,19 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12587,6 +12615,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-autolink-headings": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.0.tgz",
@@ -12611,6 +12657,23 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "react-phone-number-input": "^3.4.10",
     "react-simple-maps": "^3.0.0",
     "react-swipeable": "^7.0.1",
+    "rehype-autolink-headings": "7.1.0",
+    "rehype-slug": "6.0.0",
     "remark-directive": "^3.0.0",
     "remark-math": "^6.0.0",
     "remark-smartypants": "^2.0.0",

--- a/src/layouts/docs-layout.astro
+++ b/src/layouts/docs-layout.astro
@@ -52,3 +52,96 @@ let nav = generateDocsNav(pages);
     </div>
   </div>
 </BaseLayout>
+
+<!-- Shareable heading anchors: rehype-autolink-headings injects
+     <a class="heading-anchor" data-anchor-link><span class="heading-anchor-icon">#</span></a>
+     after every heading in MD/MDX; .astro pages add the same markup manually.
+     Styles + clipboard/scroll behaviour live here so every docs page inherits them. -->
+<style is:global>
+  .heading-anchor {
+    color: inherit;
+    text-decoration: none;
+  }
+  .heading-anchor:hover,
+  .heading-anchor:focus {
+    text-decoration: none;
+  }
+  .heading-anchor-icon {
+    display: inline-block;
+    margin-left: 0.4em;
+    font-weight: 400;
+    color: currentColor;
+    opacity: 0;
+    transition:
+      opacity 150ms ease,
+      color 150ms ease;
+    user-select: none;
+  }
+  :where(h1, h2, h3, h4, h5, h6):hover .heading-anchor-icon,
+  .heading-anchor:focus-visible .heading-anchor-icon {
+    opacity: 0.45;
+  }
+  .heading-anchor:hover .heading-anchor-icon {
+    opacity: 0.85;
+  }
+  .heading-anchor[data-copied="true"] .heading-anchor-icon {
+    opacity: 1;
+    color: #16a34a;
+  }
+  html.dark .heading-anchor[data-copied="true"] .heading-anchor-icon {
+    color: #4ade80;
+  }
+  /* Offset sticky-header height when scrolling to any in-page heading via
+     URL hash. Mirrors the per-section scroll-mt-28 used on the API reference
+     page so other docs land below the docs header on refresh. */
+  :where(h1, h2, h3, h4, h5, h6)[id] {
+    scroll-margin-top: 7rem;
+  }
+</style>
+
+<script>
+  // Heading anchor links: native <a href="#id"> handles scroll + URL hash.
+  // We additionally copy the full deep-link URL to the clipboard and show a
+  // brief green-checkmark state so users can paste directly into Slack/etc.
+  document.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement | null;
+    const link = target?.closest<HTMLAnchorElement>("[data-anchor-link]");
+    if (!link) return;
+    const href = link.getAttribute("href");
+    if (!href?.startsWith("#")) return;
+    const url = `${window.location.origin}${window.location.pathname}${href}`;
+    navigator.clipboard
+      ?.writeText(url)
+      .then(() => {
+        link.setAttribute("data-copied", "true");
+        window.setTimeout(() => link.removeAttribute("data-copied"), 1500);
+      })
+      .catch(() => {
+        // Clipboard API unavailable (older browsers / insecure context) — the
+        // anchor still navigates and updates the URL hash for manual copy.
+      });
+  });
+
+  // On initial page load with a hash, the browser's native scroll-to-anchor
+  // sometimes lands before late layout (font loading, hydration of fixed
+  // panels) settles — leaving the target behind the sticky header. Re-run the
+  // scroll after `load` and on any hashchange.
+  function scrollToHash() {
+    const hash = window.location.hash;
+    if (!hash || hash.length < 2) return;
+    let id: string;
+    try {
+      id = decodeURIComponent(hash.slice(1));
+    } catch {
+      id = hash.slice(1);
+    }
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ block: "start" });
+  }
+  if (document.readyState === "complete") {
+    scrollToHash();
+  } else {
+    window.addEventListener("load", scrollToHash, { once: true });
+  }
+  window.addEventListener("hashchange", scrollToHash);
+</script>

--- a/src/pages/docs/api-documentation/console-api/api-reference.astro
+++ b/src/pages/docs/api-documentation/console-api/api-reference.astro
@@ -314,10 +314,18 @@ const sectionsLite = sections.map((s) => ({ id: s.id, title: s.title }));
     <Breadcrumbs pathname={pathname} />
 
     <h1
-      class="text-3xl font-bold text-foreground md:text-4xl lg:text-5xl"
+      class="group/heading text-3xl font-bold text-foreground md:text-4xl lg:text-5xl"
       id="overview"
     >
-      {pageTitle}
+      <a
+        href="#overview"
+        class="heading-anchor"
+        data-anchor-link
+        aria-label={`Link to ${pageTitle}`}
+      >
+        {pageTitle}
+        <span class="heading-anchor-icon" aria-hidden="true">#</span>
+      </a>
     </h1>
 
     <p class="mt-4 max-w-3xl text-base text-para md:text-lg">
@@ -358,9 +366,17 @@ const sectionsLite = sections.map((s) => ({ id: s.id, title: s.title }));
               {group !== "core" && (
                 <h2
                   id={`group-${group}`}
-                  class="mb-4 mt-12 border-b border-defaultBorder pb-2 text-xs font-semibold uppercase tracking-widest text-para"
+                  class="group/heading mb-4 mt-12 border-b border-defaultBorder pb-2 text-xs font-semibold uppercase tracking-widest text-para"
                 >
-                  {GROUP_LABELS[group]}
+                  <a
+                    href={`#group-${group}`}
+                    class="heading-anchor"
+                    data-anchor-link
+                    aria-label={`Link to ${GROUP_LABELS[group]}`}
+                  >
+                    {GROUP_LABELS[group]}
+                    <span class="heading-anchor-icon" aria-hidden="true">#</span>
+                  </a>
                 </h2>
               )}
               {groupedSections[group].map((section) => (
@@ -370,7 +386,7 @@ const sectionsLite = sections.map((s) => ({ id: s.id, title: s.title }));
                   class="scroll-mt-28 mb-14"
                 >
                   {section.kind === "endpoint" ? (
-                    <h2 class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xl font-semibold text-foreground md:text-2xl">
+                    <h2 class="group/heading flex flex-wrap items-center gap-x-2 gap-y-1 text-xl font-semibold text-foreground md:text-2xl">
                       <MethodBadge method={section.method!} />
                       <code class="min-w-0 break-all font-mono text-base md:text-xl">
                         {section.path}
@@ -380,10 +396,26 @@ const sectionsLite = sections.map((s) => ({ id: s.id, title: s.title }));
                           Provider
                         </span>
                       )}
+                      <a
+                        href={`#${section.id}`}
+                        class="heading-anchor heading-anchor--inline"
+                        data-anchor-link
+                        aria-label={`Link to ${section.title}`}
+                      >
+                        <span class="heading-anchor-icon" aria-hidden="true">#</span>
+                      </a>
                     </h2>
                   ) : (
-                    <h2 class="text-2xl font-semibold text-foreground md:text-3xl">
-                      {section.title}
+                    <h2 class="group/heading text-2xl font-semibold text-foreground md:text-3xl">
+                      <a
+                        href={`#${section.id}`}
+                        class="heading-anchor"
+                        data-anchor-link
+                        aria-label={`Link to ${section.title}`}
+                      >
+                        {section.title}
+                        <span class="heading-anchor-icon" aria-hidden="true">#</span>
+                      </a>
                     </h2>
                   )}
 
@@ -444,7 +476,20 @@ const sectionsLite = sections.map((s) => ({ id: s.id, title: s.title }));
 
         <!-- See also -->
         <section class="mt-16 border-t border-defaultBorder pt-8">
-          <h2 class="text-xl font-semibold text-foreground">See also</h2>
+          <h2
+            id="see-also"
+            class="group/heading text-xl font-semibold text-foreground"
+          >
+            <a
+              href="#see-also"
+              class="heading-anchor"
+              data-anchor-link
+              aria-label="Link to See also"
+            >
+              See also
+              <span class="heading-anchor-icon" aria-hidden="true">#</span>
+            </a>
+          </h2>
           <ul class="mt-4 list-disc space-y-2 pl-6 text-sm text-para">
             <li>
               <a

--- a/src/pages/docs/api-documentation/getting-started.astro
+++ b/src/pages/docs/api-documentation/getting-started.astro
@@ -235,16 +235,35 @@ const helpLinks = [
 
   <div class="container-reader px-5 md:mt-10">
     <div class="flex flex-col items-start">
-      <h1 class="text-3xl font-bold md:text-4xl lg:text-5xl">
-        {pageTitle}
+      <h1 id="overview" class="text-3xl font-bold md:text-4xl lg:text-5xl">
+        <a
+          href="#overview"
+          class="heading-anchor"
+          data-anchor-link
+          aria-label={`Link to ${pageTitle}`}
+        >
+          {pageTitle}
+          <span class="heading-anchor-icon" aria-hidden="true">#</span>
+        </a>
       </h1>
       <p class="mt-6 text-base text-para md:text-lg">{pageDescription}</p>
     </div>
 
     <!-- Integration Options -->
     <div class="mt-12">
-      <h2 class="mb-6 text-2xl font-bold text-foreground md:text-3xl">
-        Integration Options
+      <h2
+        id="integration-options"
+        class="mb-6 text-2xl font-bold text-foreground md:text-3xl"
+      >
+        <a
+          href="#integration-options"
+          class="heading-anchor"
+          data-anchor-link
+          aria-label="Link to Integration Options"
+        >
+          Integration Options
+          <span class="heading-anchor-icon" aria-hidden="true">#</span>
+        </a>
       </h2>
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         {
@@ -342,8 +361,19 @@ const helpLinks = [
 
     <!-- SDK Documentation -->
     <div class="mt-12">
-      <h2 class="mb-6 text-2xl font-bold text-foreground md:text-3xl">
-        Blockchain SDK Documentation
+      <h2
+        id="blockchain-sdk-documentation"
+        class="mb-6 text-2xl font-bold text-foreground md:text-3xl"
+      >
+        <a
+          href="#blockchain-sdk-documentation"
+          class="heading-anchor"
+          data-anchor-link
+          aria-label="Link to Blockchain SDK Documentation"
+        >
+          Blockchain SDK Documentation
+          <span class="heading-anchor-icon" aria-hidden="true">#</span>
+        </a>
       </h2>
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
         {
@@ -361,8 +391,19 @@ const helpLinks = [
 
     <!-- Console API Documentation -->
     <div class="mt-12">
-      <h2 class="mb-6 text-2xl font-bold text-foreground md:text-3xl">
-        Deployment REST API Documentation
+      <h2
+        id="deployment-rest-api-documentation"
+        class="mb-6 text-2xl font-bold text-foreground md:text-3xl"
+      >
+        <a
+          href="#deployment-rest-api-documentation"
+          class="heading-anchor"
+          data-anchor-link
+          aria-label="Link to Deployment REST API Documentation"
+        >
+          Deployment REST API Documentation
+          <span class="heading-anchor-icon" aria-hidden="true">#</span>
+        </a>
       </h2>
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
         {
@@ -380,8 +421,19 @@ const helpLinks = [
 
     <!-- Console API — Network Data (indexed) -->
     <div class="mt-12">
-      <h2 class="mb-6 text-2xl font-bold text-foreground md:text-3xl">
-        Console API — Network Data (indexed)
+      <h2
+        id="console-api-network-data"
+        class="mb-6 text-2xl font-bold text-foreground md:text-3xl"
+      >
+        <a
+          href="#console-api-network-data"
+          class="heading-anchor"
+          data-anchor-link
+          aria-label="Link to Console API — Network Data (indexed)"
+        >
+          Console API — Network Data (indexed)
+          <span class="heading-anchor-icon" aria-hidden="true">#</span>
+        </a>
       </h2>
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
         {
@@ -401,8 +453,19 @@ const helpLinks = [
     <div
       class="mb-16 mt-12 rounded-lg border border-[#e6e8eb] bg-[#f8f9fa] p-8 dark:border-[#333] dark:bg-[#1a1a1a]"
     >
-      <h2 class="mb-4 text-xl font-semibold text-[#11181c] dark:text-white">
-        Need Help?
+      <h2
+        id="need-help"
+        class="mb-4 text-xl font-semibold text-[#11181c] dark:text-white"
+      >
+        <a
+          href="#need-help"
+          class="heading-anchor"
+          data-anchor-link
+          aria-label="Link to Need Help"
+        >
+          Need Help?
+          <span class="heading-anchor-icon" aria-hidden="true">#</span>
+        </a>
       </h2>
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         {


### PR DESCRIPTION
## Summary

- Hover any docs heading to reveal a `#` icon; clicking copies the deep-link URL to the clipboard and scrolls to the section (with a brief green-checkmark confirmation).
- Fixes the bug where refreshing a docs page with a hash (e.g. `…/api-reference/#get-v2deployment-settings-dseq`) sometimes landed behind the sticky header — the script re-runs `scrollIntoView` on `load` and `hashchange`.
- Coverage:
  - All MD/MDX docs pages via `rehype-slug` + `rehype-autolink-headings` (configured in `astro.config.mjs`).
  - Custom `.astro` pages (`api-reference.astro`, `api-documentation/getting-started.astro`) use the same markup applied inline.
  - Shared CSS + clipboard/scroll JS live in `docs-layout.astro` so every docs page inherits them.

## Test plan

- [x] Visit `/docs/api-documentation/console-api/api-reference/` — hover any heading (h1 overview, group headers, endpoint rows, See also), confirm the `#` icon fades in
- [x] Click an anchor — URL hash updates, page scrolls below the sticky header, icon briefly turns green, clipboard contains the full URL
- [x] Reload `…/api-reference/#get-v2deployment-settings-dseq` — page lands on the right section (not behind the header)
- [x] Visit `/docs/api-documentation/getting-started/` — same hover + click behaviour on the 6 section headings
- [x] Visit an MD/MDX page (e.g. `/docs/api-documentation/sdk/quick-start/`, `/docs/api-documentation/rest-api/providers-api/`) — every `##` / `###` has a working anchor
- [x] Dark mode — icon visible, `data-copied` green still legible
- [x] Right-side TOC / `ApiReferencePanel` still tracks the active section as before