### PR TITLE
docs(console-api): fix provider lease shell endpoint sample

### DIFF
--- a/src/lib/docs/console-api-endpoints.ts
+++ b/src/lib/docs/console-api-endpoints.ts
@@ -1141,7 +1141,7 @@ ws.on("message", (chunk) => console.log(JSON.parse(chunk.toString())));`,
     notes: [
       "JWT scope must include `shell`.",
       "Command and arguments are passed as separate numbered query params (`cmd0`, `cmd1`, …) — there is no single base64-encoded `cmd` param. `tty` and `stdin` are required.",
-      "The example above is a one-shot command (`tty=0&stdin=0`). For an interactive session, set `tty=1&stdin=1`, stream keystrokes as `104`-prefixed binary frames, and send terminal resizes as `105` frames. Most users should use the Akash CLI (`provider-services lease-shell --tty`) or SDK helpers instead of driving this directly.",
+      "The example above is a one-shot command (`tty=0&stdin=0`). For an interactive session, set `tty=1&stdin=1`, stream keystrokes as `104`-prefixed binary frames, and send terminal resizes as `105` frames. Most users should use the Akash CLI (`provider-services lease-shell --tty`) or SDK helpers instead of driving this directly — see [Shell Access](/docs/learn/core-concepts/shell-access/).",
       "Console UI uses `xterm.js` on the client side to render the stream.",
       "For programmatic shells, use the provider's `kubectl exec`-style protocol via the SDK helpers rather than constructing this WebSocket by hand.",
     ],

--- a/src/lib/docs/console-api-endpoints.ts
+++ b/src/lib/docs/console-api-endpoints.ts
@@ -1131,13 +1131,16 @@ ws.on("message", (chunk) => console.log(JSON.parse(chunk.toString())));`,
       { field: "oseq", location: "path", type: "number", required: true, description: "Order sequence" },
       { field: "service", location: "query", type: "string", required: true, description: "Service name to exec into" },
       { field: "podIndex", location: "query", type: "number", required: true, description: "Pod index (zero-based)" },
-      { field: "cmd", location: "query", type: "string", required: false, description: "Base64-encoded command to run (omit for default shell)" },
+      { field: "tty", location: "query", type: "number", required: true, description: "`1` to allocate a TTY, `0` otherwise" },
+      { field: "stdin", location: "query", type: "number", required: true, description: "`1` to attach stdin, `0` otherwise" },
+      { field: "cmd0, cmd1, …", location: "query", type: "string", required: true, description: "Command and each argument as separate numbered params, e.g. `cmd0=/bin/sh&cmd1=-c&cmd2=ls`. There is no single (or base64) `cmd` param." },
     ],
     responseFields: [
-      { field: "(stream)", type: "binary", description: "Multiplexed stdin/stdout/stderr/resize frames" },
+      { field: "(stream)", type: "binary", description: "Multiplexed binary frames; the first byte is the stream code — 100=stdout, 101=stderr, 102=result (JSON, e.g. {\\\"exit_code\\\":0}), 103=failure. Client→server uses 104=stdin, 105=terminal-resize." },
     ],
     notes: [
       "JWT scope must include `shell`.",
+      "Command and arguments are passed as separate numbered query params (`cmd0`, `cmd1`, …) — there is no single base64-encoded `cmd` param. `tty` and `stdin` are required.",
       "Console UI uses `xterm.js` on the client side to render the stream.",
       "For programmatic shells, use the provider's `kubectl exec`-style protocol via the SDK helpers rather than constructing this WebSocket by hand.",
     ],
@@ -1147,19 +1150,41 @@ ws.on("message", (chunk) => console.log(JSON.parse(chunk.toString())));`,
         code: `import WebSocket from "ws";
 import https from "https";
 
-// \`rejectUnauthorized: false\` skips Node's hostname check; see preface.
+// \`rejectUnauthorized: false\` skips Node's CA check — the provider cert is
+// pinned to the on-chain wallet address, not a public CA; see preface.
 const agent = new https.Agent({ rejectUnauthorized: false });
 
-const cmd = Buffer.from(JSON.stringify(["/bin/sh"])).toString("base64");
+// Command + args go in SEPARATE numbered params (cmd0, cmd1, …); there is no
+// base64 \`cmd\` param. \`tty\` and \`stdin\` are required.
+const params = new URLSearchParams();
+["/bin/sh", "-c", "echo hello && hostname"].forEach((arg, i) =>
+  params.append(\`cmd\${i}\`, arg)
+);
+params.append("tty", "0");
+params.append("stdin", "0");
+params.append("service", service);
+params.append("podIndex", "0");
+
 const url =
-  \`wss://\${hostUri.replace(/^https?:\\/\\//, "")}/lease/\${dseq}/\${gseq}/\${oseq}/shell\` +
-  \`?service=\${service}&podIndex=0&cmd=\${cmd}\`;
+  \`wss://\${hostUri.replace(/^https?:\\/\\//, "")}/lease/\${dseq}/\${gseq}/\${oseq}/shell?\${params}\`;
 
 const ws = new WebSocket(url, {
   headers: { Authorization: \`Bearer \${jwt}\` },
   agent,
 });
-ws.on("message", (frame) => process.stdout.write(frame));`,
+
+// Frames are binary: the first byte is the stream code.
+ws.on("message", (frame) => {
+  const code = frame[0];
+  const data = frame.subarray(1);
+  if (code === 100) process.stdout.write(data); // stdout
+  else if (code === 101) process.stderr.write(data); // stderr
+  else if (code === 102) {
+    // result frame, e.g. {"exit_code":0}
+    console.log("result:", data.toString());
+    ws.close();
+  }
+});`,
       },
     ],
   },

--- a/src/lib/docs/console-api-endpoints.ts
+++ b/src/lib/docs/console-api-endpoints.ts
@@ -1141,6 +1141,7 @@ ws.on("message", (chunk) => console.log(JSON.parse(chunk.toString())));`,
     notes: [
       "JWT scope must include `shell`.",
       "Command and arguments are passed as separate numbered query params (`cmd0`, `cmd1`, …) — there is no single base64-encoded `cmd` param. `tty` and `stdin` are required.",
+      "The example above is a one-shot command (`tty=0&stdin=0`). For an interactive session, set `tty=1&stdin=1`, stream keystrokes as `104`-prefixed binary frames, and send terminal resizes as `105` frames. Most users should use the Akash CLI (`provider-services lease-shell --tty`) or SDK helpers instead of driving this directly.",
       "Console UI uses `xterm.js` on the client side to render the stream.",
       "For programmatic shells, use the provider's `kubectl exec`-style protocol via the SDK helpers rather than constructing this WebSocket by hand.",
     ],


### PR DESCRIPTION
## What

The API reference's **WSS `/lease/{dseq}/{gseq}/{oseq}/shell`** sample (`src/lib/docs/console-api-endpoints.ts`) doesn't match what the provider actually accepts, so copy-pasting it fails.

### Problems
- **`cmd` is wrong.** The sample sends a single base64-encoded `cmd` query param. The provider reads command + args as **separate numbered params** (`cmd0`, `cmd1`, …) and never base64-decodes.
- **`tty` and `stdin` are missing.** Both are **required** — the provider returns `missing parameter tty` / `missing parameter stdin` without them.
- **Frame handling is wrong.** The sample does `process.stdout.write(frame)`, writing the raw frame including its leading stream-code byte. Frames are binary and demuxed by the first byte.

### Fix
- `requestParams`: add required `tty` and `stdin`; replace the base64 `cmd` row with numbered `cmd0, cmd1, …`.
- `responseFields`: document the binary framing (100=stdout, 101=stderr, 102=result, 103=failure; 104=stdin, 105=resize).
- `codeSnippets`: corrected, working JS sample that builds numbered `cmd*` params + `tty`/`stdin` and demuxes frames by stream code.
- `notes`: call out the numbered-param + required `tty`/`stdin` behavior.

## How verified
Tested end-to-end against a **live lease** on `provider.hurricane.akash.pub` — the corrected query round-trips a command and returns `{"exit_code":0}`. Cross-checked against the provider source [`gateway/rest/router.go`](https://github.com/akash-network/provider/blob/main/gateway/rest/router.go) `leaseShellHandler` (params `cmd0..N`, `tty`, `stdin`, `service`, `podIndex`) and `constants.go` (frame codes).

The other provider-direct samples on this page (status `curl -k`, logs/kubeevents `websocat --insecure` with `follow`/`tail`/`service`, and the `events`→`kubeevents` note) were tested in the same run and are **correct** — no changes needed there.