### PR TITLE
docs: confidential compute

### DIFF
--- a/src/content/Docs/developers/deployment/akash-sdl/advanced-features/index.md
+++ b/src/content/Docs/developers/deployment/akash-sdl/advanced-features/index.md
@@ -256,6 +256,80 @@ If the `reclamation` block is omitted, reclamation is not required and any provi
 
 ---
 
+## Confidential Compute (TEE)
+
+Request hardware-isolated Trusted Execution Environments (TEE) to fully secure your workloads during processing. Akash supports AMD SEV-SNP and Intel TDX with optional NVIDIA GPU Confidential Computing.
+
+### Basic TEE Request
+
+Add a `params.tee` block to any service:
+
+```yaml
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        to:
+          - global: true
+    params:
+      tee:
+        type: sev-snp
+```
+
+Use `tdx` for Intel TDX instead of `sev-snp`.
+
+### GPU + TEE
+
+Combine GPU workloads with Confidential Compute:
+
+```yaml
+services:
+  inference:
+    image: my-model:latest
+    expose:
+      - port: 8080
+        to:
+          - global: true
+    params:
+      tee:
+        type: tdx-gpu
+
+profiles:
+  compute:
+    inference:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 256Mi
+        storage:
+          size: 128Mi
+        gpu:
+          units: 1
+          attributes:
+            vendor:
+              nvidia:
+```
+
+Use `sev-snp-gpu` instead of `tdx-gpu` for AMD hardware.
+
+### TEE Type Reference
+
+| Value | Runtime Class | Hardware |
+|-------|---------------|----------|
+| `sev-snp` | `kata-qemu-snp` | AMD with SEV-SNP |
+| `sev-snp-gpu` | `kata-qemu-nvidia-gpu-snp` | AMD SEV-SNP + NVIDIA CC GPU |
+| `tdx` | `kata-qemu-tdx` | Intel with TDX |
+| `tdx-gpu` | `kata-qemu-nvidia-gpu-tdx` | Intel TDX + NVIDIA CC GPU |
+
+For attestation, security model details, and provider setup, see:
+
+- [Confidential Compute (TEE) Core Concepts](/docs/learn/core-concepts/confidential-compute)
+- [Provider Confidential Compute Setup](/docs/providers/setup-and-installation/kubespray/confidential-compute)
+
+---
+
 ## IP Endpoints (Dedicated IPs)
 
 ### Basic IP Endpoint

--- a/src/content/Docs/developers/deployment/akash-sdl/advanced-features/index.md
+++ b/src/content/Docs/developers/deployment/akash-sdl/advanced-features/index.md
@@ -258,11 +258,11 @@ If the `reclamation` block is omitted, reclamation is not required and any provi
 
 ## Confidential Compute (TEE)
 
-Request hardware-isolated Trusted Execution Environments (TEE) to fully secure your workloads during processing. Akash supports AMD SEV-SNP and Intel TDX with optional NVIDIA GPU Confidential Computing.
+Request hardware-isolated Trusted Execution Environments (TEE) to fully secure your workloads during processing. Akash supports AMD SEV-SNP and Intel TDX with optional NVIDIA GPU Confidential Computing. You specify a TEE *capability* in SDL; the provider resolves the actual hardware *platform* at deployment time.
 
 ### Basic TEE Request
 
-Add a `params.tee` block to any service:
+Set `params.tee` to `cpu` for a CPU-only confidential VM:
 
 ```yaml
 services:
@@ -273,15 +273,12 @@ services:
         to:
           - global: true
     params:
-      tee:
-        type: sev-snp
+      tee: cpu
 ```
-
-Use `tdx` for Intel TDX instead of `sev-snp`.
 
 ### GPU + TEE
 
-Combine GPU workloads with Confidential Compute:
+Use `cpu-gpu` to combine Confidential Compute with GPU acceleration. This must be paired with GPU resources in the compute profile:
 
 ```yaml
 services:
@@ -292,8 +289,7 @@ services:
         to:
           - global: true
     params:
-      tee:
-        type: tdx-gpu
+      tee: cpu-gpu
 
 profiles:
   compute:
@@ -312,16 +308,14 @@ profiles:
               nvidia:
 ```
 
-Use `sev-snp-gpu` instead of `tdx-gpu` for AMD hardware.
-
 ### TEE Type Reference
 
-| Value | Runtime Class | Hardware |
-|-------|---------------|----------|
-| `sev-snp` | `kata-qemu-snp` | AMD with SEV-SNP |
-| `sev-snp-gpu` | `kata-qemu-nvidia-gpu-snp` | AMD SEV-SNP + NVIDIA CC GPU |
-| `tdx` | `kata-qemu-tdx` | Intel with TDX |
-| `tdx-gpu` | `kata-qemu-nvidia-gpu-tdx` | Intel TDX + NVIDIA CC GPU |
+The `params.tee` field accepts the following values:
+
+| Value | Runtime Class (Intel TDX) | Runtime Class (AMD SEV-SNP) | Description |
+|-------|---------------------------|-----------------------------|-------------|
+| `cpu` | `kata-qemu-tdx` | `kata-qemu-snp` | CPU-only confidential VM |
+| `cpu-gpu` | `kata-qemu-nvidia-gpu-tdx` | `kata-qemu-nvidia-gpu-snp` | Confidential VM with NVIDIA GPU CC |
 
 For attestation, security model details, and provider setup, see:
 

--- a/src/content/Docs/learn/core-concepts/confidential-compute/index.md
+++ b/src/content/Docs/learn/core-concepts/confidential-compute/index.md
@@ -287,6 +287,7 @@ The attestation design enforces these properties:
 - **Performance**: Memory encryption adds a small overhead (~1-5%). GPU Confidential Computing may add further overhead depending on the workload.
 - **Sidecar resources**: The attestation sidecar consumes modest resources (10m CPU, 32-64Mi memory) which are automatically included in resource accounting.
 - **Runtime environment**: TEE workloads run inside Kata VMs rather than standard containers. Most workloads are unaffected, but features that depend on direct host kernel access may behave differently.
+- **Distroless and scratch-based images are not supported.** Kata Containers uses a guest agent inside the VM to set up and manage the container filesystem. Images built `FROM scratch` or from `gcr.io/distroless/...` lack the minimal filesystem structure (e.g. `/dev`, `/proc`, `/sys`) that the guest agent requires to initialize the container. Use a minimal but complete base image such as `alpine` or `ubuntu` instead.
 
 ---
 

--- a/src/content/Docs/learn/core-concepts/confidential-compute/index.md
+++ b/src/content/Docs/learn/core-concepts/confidential-compute/index.md
@@ -227,28 +227,7 @@ provider-services lease-attestation \
 
 ### API Reference
 
-For programmatic verification, the attestation API has two endpoints.
-
-#### Discovery (Directory)
-
-Returns routing hints to locate the attestation sidecar. This endpoint is unauthenticated.
-
-```
-GET /attestation/directory/{dseq}/{gseq}/{oseq}
-```
-
-```json
-{
-  "endpoint": "https://<sidecar-url>/quote",
-  "tee_type": "amd-sev-snp",
-  "runtime_class": "kata-qemu-snp",
-  "protocol_version": "2",
-  "expected_launch_measurement": "<hex>",
-  "expected_image_digest": "<digest>"
-}
-```
-
-> **Important:** The directory response is **untrusted**. All values are advisory routing hints only. You must verify claims against the hardware-signed attestation report.
+For programmatic verification, the attestation API has the following endpoints.
 
 #### Quote (Challenge-Response)
 

--- a/src/content/Docs/learn/core-concepts/confidential-compute/index.md
+++ b/src/content/Docs/learn/core-concepts/confidential-compute/index.md
@@ -273,12 +273,17 @@ Response:
   "cert_chain": "<base64-certificate-chain>",
   "tee_type": "snp",
   "auxblob": "<base64-auxiliary-blob>",
-  "gpu_report": "<base64-gpu-attestation (present for GPU TEE types)>",
+  "gpu_reports": [
+    {
+      "device_index": 0,
+      "report": "<base64-gpu-attestation>"
+    }
+  ],
   "tls_bound": false
 }
 ```
 
-The `report` field contains the raw hardware-signed attestation evidence (an SNP report or TDX quote). Verify it using AMD's or Intel's published root certificates to confirm authenticity.
+The `report` field contains the raw hardware-signed attestation evidence (an SNP report or TDX quote). For GPU TEE types, `gpu_reports` contains a per-device entry for every GPU in the workload, each with its own hardware-signed attestation evidence. Verify GPU reports against NVIDIA's published root certificates.
 
 ### TLS Channel Binding
 

--- a/src/content/Docs/learn/core-concepts/confidential-compute/index.md
+++ b/src/content/Docs/learn/core-concepts/confidential-compute/index.md
@@ -9,9 +9,9 @@ description: "Deploy workloads inside hardware-backed Trusted Execution Environm
 
 **Deploy workloads inside hardware-isolated Trusted Execution Environments (TEEs) where neither the provider nor any other party can access your data or code in memory.**
 
-Standard cloud deployments require trusting the infrastructure operator. Confidential Compute eliminates that requirement. Containers run inside encrypted virtual machines where the CPU hardware enforces isolation, the provider's OS, hypervisor and administrators cannot inspect the workload's memory.
+Standard cloud deployments require trusting the infrastructure operator. Confidential Compute eliminates that requirement. Containers run inside encrypted virtual machines where the CPU hardware enforces isolation, so the provider's OS, hypervisor, and administrators cannot inspect the workload's memory.
 
-Akash supports AMD SEV-SNP and Intel TDX, with optional NVIDIA GPU Confidential Computing for GPU-accelerated workloads.
+Akash supports AMD SEV-SNP and Intel TDX. Tenants specify a TEE *capability* (`cpu` or `cpu-gpu`) in their SDL, and the provider resolves the actual hardware *platform* (`snp` or `tdx`) at deployment time based on its cluster nodes. NVIDIA GPU Confidential Computing is available with the `cpu-gpu` capability.
 
 ---
 
@@ -44,29 +44,37 @@ In a standard deployment, the provider's operating system has full access to con
 
 ## Supported TEE Types
 
-Akash currently supports four TEE configurations:
+Akash uses capability-based TEE types. You choose the workload type; the provider resolves the hardware platform.
 
-| TEE Type | SDL Value | Description |
-|----------|-----------|-------------|
-| AMD SEV-SNP | `sev-snp` | CPU-only confidential VM on AMD hardware |
-| AMD SEV-SNP + GPU | `sev-snp-gpu` | SEV-SNP with NVIDIA GPU Confidential Computing |
-| Intel TDX | `tdx` | CPU-only confidential VM on Intel hardware |
-| Intel TDX + GPU | `tdx-gpu` | TDX with NVIDIA GPU Confidential Computing |
+| Capability | SDL Value | Description |
+|------------|-----------|-------------|
+| CPU-only TEE | `cpu` | Confidential VM with CPU memory encryption |
+| CPU + GPU TEE | `cpu-gpu` | Confidential VM with CPU memory encryption plus NVIDIA GPU Confidential Computing |
 
-Both `sev-snp` and `tdx` provide equivalent security guarantees. The choice depends on the provider's hardware. Use the `-gpu` variants when your workload requires GPU acceleration (e.g., AI inference or training).
+The provider selects the actual runtime class based on its detected hardware platform:
+
+| Capability | Platform | Runtime Class |
+|------------|----------|---------------|
+| `cpu` | Intel TDX (`tdx`) | `kata-qemu-tdx` |
+| `cpu` | AMD SEV-SNP (`snp`) | `kata-qemu-snp` |
+| `cpu-gpu` | Intel TDX (`tdx`) | `kata-qemu-nvidia-gpu-tdx` |
+| `cpu-gpu` | AMD SEV-SNP (`snp`) | `kata-qemu-nvidia-gpu-snp` |
+
+Both Intel TDX and AMD SEV-SNP provide equivalent security guarantees. The actual platform used depends on the provider's hardware. Use `cpu-gpu` when your workload requires GPU acceleration (e.g., AI inference or training).
 
 ---
 
 ## How It Works
 
-Deploying a confidential workload requires only a `params.tee` block in your SDL. The platform handles the rest:
+Deploying a confidential workload requires only a `params.tee` value in your SDL. The platform handles the rest:
 
-1. **Your SDL specifies the TEE type** via `params.tee.type`
-2. **The provider schedules the workload** on a TEE-capable node
-3. **A Kata Container VM launches inside the hardware TEE** (AMD SEV-SNP or Intel TDX)
-4. **Your container runs inside the encrypted VM** and all memory is hardware-encrypted
-5. **Bring your own attestation stack or Akash injects its own** alongside your workload
-6. **You can verify the TEE** by requesting to the provider a hardware-signed attestation report at any time
+1. **Your SDL specifies the TEE capability** via `params.tee` (`cpu` or `cpu-gpu`)
+2. **The chain-SDK projects `tee/type=<value>`** as a placement requirement so only capable providers can bid
+3. **The provider matches the bid** using its advertised `tee/type` attribute and resolves the RuntimeClass from the requested capability plus its detected hardware platform (`tdx` or `snp`)
+4. **A Kata Container VM launches inside the hardware TEE** (AMD SEV-SNP or Intel TDX)
+5. **Your container runs inside the encrypted VM** and all memory is hardware-encrypted
+6. **The Akash attestation sidecar is injected by default** (unless disabled by the tenant)
+7. **You can verify the TEE** at any time by requesting a hardware-signed attestation report from the provider
 
 Everything inside the VM boundary is encrypted. The provider's OS and administrators cannot access it.
 
@@ -74,9 +82,9 @@ Everything inside the VM boundary is encrypted. The provider's OS and administra
 
 ## SDL Configuration
 
-Add a `params.tee` block to your service definition. The rest of the SDL remains unchanged.
+Set `params.tee` to the desired capability in your service definition. The rest of the SDL remains unchanged.
 
-### Basic Example — AMD SEV-SNP
+### Basic Example — CPU-only TEE
 
 ```yaml
 ---
@@ -91,8 +99,7 @@ services:
         to:
           - global: true
     params:
-      tee:
-        type: sev-snp
+      tee: cpu
 
 profiles:
   compute:
@@ -118,27 +125,9 @@ deployment:
       count: 1
 ```
 
-### Basic Example — Intel TDX
-
-The only change is the TEE type:
-
-```yaml
-services:
-  web:
-    image: nginx
-    expose:
-      - port: 80
-        as: 80
-        to:
-          - global: true
-    params:
-      tee:
-        type: tdx
-```
-
 ### GPU + TEE Example
 
-To combine GPU workloads with Confidential Compute, use a GPU TEE type and add GPU resources:
+To combine GPU workloads with Confidential Compute, use `cpu-gpu` and add GPU resources:
 
 ```yaml
 ---
@@ -153,8 +142,7 @@ services:
         to:
           - global: true
     params:
-      tee:
-        type: tdx-gpu
+      tee: cpu-gpu
 
 profiles:
   compute:
@@ -185,18 +173,16 @@ deployment:
       count: 1
 ```
 
-> You can also use `sev-snp-gpu` instead of `tdx-gpu` depending on which TEE hardware the provider offers.
-
 ### TEE Type Reference
 
-The `params.tee.type` field accepts the following values:
+The `params.tee` field accepts the following values:
 
-| Value | Runtime Class | Hardware Required |
-|-------|---------------|-------------------|
-| `sev-snp` | `kata-qemu-snp` | AMD with SEV-SNP |
-| `sev-snp-gpu` | `kata-qemu-nvidia-gpu-snp` | AMD with SEV-SNP + NVIDIA CC GPU |
-| `tdx` | `kata-qemu-tdx` | Intel with TDX |
-| `tdx-gpu` | `kata-qemu-nvidia-gpu-tdx` | Intel with TDX + NVIDIA CC GPU |
+| Value | Runtime Class (Intel TDX) | Runtime Class (AMD SEV-SNP) | Description |
+|-------|---------------------------|-----------------------------|-------------|
+| `cpu` | `kata-qemu-tdx` | `kata-qemu-snp` | CPU-only confidential VM |
+| `cpu-gpu` | `kata-qemu-nvidia-gpu-tdx` | `kata-qemu-nvidia-gpu-snp` | Confidential VM with NVIDIA GPU CC |
+
+`cpu-gpu` must be paired with GPU resources in the compute profile. GPU CC workloads request the `nvidia.com/pgpu` Kubernetes resource for VFIO passthrough.
 
 ---
 
@@ -206,11 +192,10 @@ Attestation is how you verify that your workload is genuinely running inside a h
 
 ### Overview
 
-The attestation flow has three stages:
+The attestation flow has two stages:
 
-1. **Discovery**: Query the provider's directory API to locate the attestation component for your lease
-2. **Challenge**: Send a random 64-byte nonce (your challenge) to the provider. The nonce ensures the report is fresh and was generated for your specific request
-3. **Verification**: The attestation component returns a hardware-signed report. Verify it against AMD or Intel root-of-trust certificates to confirm the TEE is genuine
+1. **Challenge**: Send a random 64-byte nonce (your challenge) to the provider's attestation quote endpoint. The nonce ensures the report is fresh and was generated for your specific request
+2. **Verification**: The provider proxies your request to the in-pod attestation sidecar, which returns a hardware-signed report. Verify it against AMD's, Intel's, or NVIDIA's published root-of-trust certificates to confirm the TEE is genuine
 
 ### Using the CLI
 
@@ -227,7 +212,7 @@ provider-services lease-attestation \
 
 ### API Reference
 
-For programmatic verification, the attestation API has the following endpoints.
+The attestation API exposes a single quote endpoint. The provider forwards your nonce to the attestation sidecar running inside the TEE and returns the hardware-signed response verbatim.
 
 #### Quote (Challenge-Response)
 
@@ -273,7 +258,6 @@ Setting `bind_tls: true` binds the attestation report to the current TLS session
 The attestation design enforces these properties:
 
 - **Provider cannot modify evidence** — the nonce and hardware report are passed through verbatim
-- **Directory hints are untrusted** — they are routing aids only; always verify against the hardware-signed report
 - **Nonce proves freshness** — the hardware includes your nonce in `REPORT_DATA`, proving the report was generated for your request
 - **Channel binding is optional but recommended** — for sensitive workloads, use `bind_tls: true` to prevent attestation relay
 
@@ -290,6 +274,7 @@ The attestation design enforces these properties:
 
 ## Related Topics
 
+- [CC Hardware Compatibility](/docs/providers/operations/confidential-compute-hardware) — Which CPUs and GPUs support Confidential Compute
 - [Provider Confidential Compute Setup](/docs/providers/setup-and-installation/kubespray/confidential-compute) — How providers enable TEE support
 - [GPU Deployments](/docs/learn/core-concepts/gpu-deployments) — General GPU deployment guide
 - [Provider Attributes](/docs/providers/operations/provider-attributes) — How providers advertise TEE capabilities

--- a/src/content/Docs/learn/core-concepts/confidential-compute/index.md
+++ b/src/content/Docs/learn/core-concepts/confidential-compute/index.md
@@ -247,7 +247,25 @@ Response:
 }
 ```
 
-The `report` field contains the raw hardware-signed attestation evidence (an SNP report or TDX quote). For GPU TEE types, `gpu_reports` contains a per-device entry for every GPU in the workload, each with its own hardware-signed attestation evidence. Verify GPU reports against NVIDIA's published root certificates.
+The `report` field contains the raw hardware-signed attestation evidence (an SNP report or TDX quote). For GPU TEE types, `gpu_reports` contains a per-device entry for every GPU in the workload.
+
+### GPU Report Format
+
+Each `gpu_reports[].report` value is a base64-encoded blob that contains two concatenated parts:
+
+```
+[SPDM evidence (variable length)][PEM certificate chain (variable length)]
+```
+
+Split on the first `-----BEGIN CERTIFICATE-----` marker to separate them:
+
+- **Before the marker** — SPDM measurement records and signature (the GPU attestation evidence)
+- **From the marker onward** — PEM-encoded certificate chain, 5 certificates in order:
+  1. Device certificate (leaf)
+  2. GSP BROM certificate
+  3. Provisioner ICA
+  4. Identity CA
+  5. NVIDIA Device Identity CA (self-signed root)
 
 ### TLS Channel Binding
 

--- a/src/content/Docs/learn/core-concepts/confidential-compute/index.md
+++ b/src/content/Docs/learn/core-concepts/confidential-compute/index.md
@@ -1,0 +1,311 @@
+---
+categories: ["Learn", "Core Concepts"]
+tags: ["Confidential Compute", "TEE", "Security", "Privacy", "GPU"]
+weight: 7
+title: "Confidential Compute (TEE)"
+linkTitle: "Confidential Compute"
+description: "Deploy workloads inside hardware-backed Trusted Execution Environments on Akash Network"
+---
+
+**Deploy workloads inside hardware-isolated Trusted Execution Environments (TEEs) where neither the provider nor any other party can access your data or code in memory.**
+
+Standard cloud deployments require trusting the infrastructure operator. Confidential Compute eliminates that requirement. Containers run inside encrypted virtual machines where the CPU hardware enforces isolation, the provider's OS, hypervisor and administrators cannot inspect the workload's memory.
+
+Akash supports AMD SEV-SNP and Intel TDX, with optional NVIDIA GPU Confidential Computing for GPU-accelerated workloads.
+
+---
+
+## Why Confidential Compute?
+
+### Hardware-Enforced Isolation
+
+In a standard deployment, the provider's operating system has full access to container memory. With Confidential Compute:
+
+- **Memory is encrypted by the CPU**, this means the provider's OS, hypervisor and administrators cannot read it
+- **Workloads run in a Trusted Execution Environment (TEE)**, which is an hardware-level isolation, not software sandboxing
+- **Attestation provides cryptographic proof** that the workload is running in a genuine TEE with the expected configuration
+- **GPU memory can also be protected** via NVIDIA Confidential Computing
+
+### Use Cases
+
+**AI & Machine Learning:**
+- Private model inference (protect proprietary models)
+- Confidential fine-tuning on sensitive data
+
+**Healthcare:**
+- Processing protected health information (PHI)
+- Drug discovery on confidential compounds
+
+**General Privacy:**
+- Any workload handling secrets, PII or proprietary algorithms
+- Zero-trust deployments where you cannot trust the infrastructure
+
+---
+
+## Supported TEE Types
+
+Akash currently supports four TEE configurations:
+
+| TEE Type | SDL Value | Description |
+|----------|-----------|-------------|
+| AMD SEV-SNP | `sev-snp` | CPU-only confidential VM on AMD hardware |
+| AMD SEV-SNP + GPU | `sev-snp-gpu` | SEV-SNP with NVIDIA GPU Confidential Computing |
+| Intel TDX | `tdx` | CPU-only confidential VM on Intel hardware |
+| Intel TDX + GPU | `tdx-gpu` | TDX with NVIDIA GPU Confidential Computing |
+
+Both `sev-snp` and `tdx` provide equivalent security guarantees. The choice depends on the provider's hardware. Use the `-gpu` variants when your workload requires GPU acceleration (e.g., AI inference or training).
+
+---
+
+## How It Works
+
+Deploying a confidential workload requires only a `params.tee` block in your SDL. The platform handles the rest:
+
+1. **Your SDL specifies the TEE type** via `params.tee.type`
+2. **The provider schedules the workload** on a TEE-capable node
+3. **A Kata Container VM launches inside the hardware TEE** (AMD SEV-SNP or Intel TDX)
+4. **Your container runs inside the encrypted VM** and all memory is hardware-encrypted
+5. **Bring your own attestation stack or Akash injects its own** alongside your workload
+6. **You can verify the TEE** by requesting to the provider a hardware-signed attestation report at any time
+
+Everything inside the VM boundary is encrypted. The provider's OS and administrators cannot access it.
+
+---
+
+## SDL Configuration
+
+Add a `params.tee` block to your service definition. The rest of the SDL remains unchanged.
+
+### Basic Example — AMD SEV-SNP
+
+```yaml
+---
+version: "2.1"
+
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+    params:
+      tee:
+        type: sev-snp
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 256Mi
+        storage:
+          size: 128Mi
+  placement:
+    westcoast:
+      pricing:
+        web:
+          denom: uact
+          amount: 1000
+
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+```
+
+### Basic Example — Intel TDX
+
+The only change is the TEE type:
+
+```yaml
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+    params:
+      tee:
+        type: tdx
+```
+
+### GPU + TEE Example
+
+To combine GPU workloads with Confidential Compute, use a GPU TEE type and add GPU resources:
+
+```yaml
+---
+version: "2.1"
+
+services:
+  inference:
+    image: my-private-model:latest
+    expose:
+      - port: 8080
+        as: 80
+        to:
+          - global: true
+    params:
+      tee:
+        type: tdx-gpu
+
+profiles:
+  compute:
+    inference:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 256Mi
+        storage:
+          size: 128Mi
+        gpu:
+          units: 1
+          attributes:
+            vendor:
+              nvidia:
+  placement:
+    westcoast:
+      pricing:
+        inference:
+          denom: uact
+          amount: 10000
+
+deployment:
+  inference:
+    westcoast:
+      profile: inference
+      count: 1
+```
+
+> You can also use `sev-snp-gpu` instead of `tdx-gpu` depending on which TEE hardware the provider offers.
+
+### TEE Type Reference
+
+The `params.tee.type` field accepts the following values:
+
+| Value | Runtime Class | Hardware Required |
+|-------|---------------|-------------------|
+| `sev-snp` | `kata-qemu-snp` | AMD with SEV-SNP |
+| `sev-snp-gpu` | `kata-qemu-nvidia-gpu-snp` | AMD with SEV-SNP + NVIDIA CC GPU |
+| `tdx` | `kata-qemu-tdx` | Intel with TDX |
+| `tdx-gpu` | `kata-qemu-nvidia-gpu-tdx` | Intel with TDX + NVIDIA CC GPU |
+
+---
+
+## Attestation
+
+Attestation is how you verify that your workload is genuinely running inside a hardware TEE. The attestation report is signed by the CPU hardware itself and the provider cannot forge or tamper with it.
+
+### Overview
+
+The attestation flow has three stages:
+
+1. **Discovery**: Query the provider's directory API to locate the attestation component for your lease
+2. **Challenge**: Send a random 64-byte nonce (your challenge) to the provider. The nonce ensures the report is fresh and was generated for your specific request
+3. **Verification**: The attestation component returns a hardware-signed report. Verify it against AMD or Intel root-of-trust certificates to confirm the TEE is genuine
+
+### Using the CLI
+
+The simplest way to request attestation:
+
+```bash
+provider-services lease-attestation \
+  --dseq <deployment-sequence> \
+  --gseq <group-sequence> \
+  --oseq <order-sequence> \
+  --provider <provider-address> \
+  --from <your-key>
+```
+
+### API Reference
+
+For programmatic verification, the attestation API has two endpoints.
+
+#### Discovery (Directory)
+
+Returns routing hints to locate the attestation sidecar. This endpoint is unauthenticated.
+
+```
+GET /attestation/directory/{dseq}/{gseq}/{oseq}
+```
+
+```json
+{
+  "endpoint": "https://<sidecar-url>/quote",
+  "tee_type": "amd-sev-snp",
+  "runtime_class": "kata-qemu-snp",
+  "protocol_version": "2",
+  "expected_launch_measurement": "<hex>",
+  "expected_image_digest": "<digest>"
+}
+```
+
+> **Important:** The directory response is **untrusted**. All values are advisory routing hints only. You must verify claims against the hardware-signed attestation report.
+
+#### Quote (Challenge-Response)
+
+Send your nonce to receive a hardware-signed attestation report:
+
+```
+POST /lease/{dseq}/{gseq}/{oseq}/attestation/quote
+```
+
+Request:
+```json
+{
+  "nonce": "<base64-encoded-64-bytes>",
+  "bind_tls": false
+}
+```
+
+Response:
+```json
+{
+  "report": "<base64-raw-attestation-report>",
+  "cert_chain": "<base64-certificate-chain>",
+  "tee_type": "snp",
+  "auxblob": "<base64-auxiliary-blob>",
+  "gpu_report": "<base64-gpu-attestation (present for GPU TEE types)>",
+  "tls_bound": false
+}
+```
+
+The `report` field contains the raw hardware-signed attestation evidence (an SNP report or TDX quote). Verify it using AMD's or Intel's published root certificates to confirm authenticity.
+
+### TLS Channel Binding
+
+Setting `bind_tls: true` binds the attestation report to the current TLS session. The sidecar computes `SHA-512(tls_public_key || nonce)[:64]` and places the result in the report's `REPORT_DATA` field. This proves the attestation came from the same endpoint you're connected to, preventing relay attacks.
+
+### Security Model
+
+The attestation design enforces these properties:
+
+- **Provider cannot modify evidence** — the nonce and hardware report are passed through verbatim
+- **Directory hints are untrusted** — they are routing aids only; always verify against the hardware-signed report
+- **Nonce proves freshness** — the hardware includes your nonce in `REPORT_DATA`, proving the report was generated for your request
+- **Channel binding is optional but recommended** — for sensitive workloads, use `bind_tls: true` to prevent attestation relay
+
+---
+
+## Limitations and Considerations
+
+- **Provider availability**: Only providers with TEE-capable hardware can accept confidential workloads. Look for the `tee/type` attribute when selecting a provider.
+- **Performance**: Memory encryption adds a small overhead (~1-5%). GPU Confidential Computing may add further overhead depending on the workload.
+- **Sidecar resources**: The attestation sidecar consumes modest resources (10m CPU, 32-64Mi memory) which are automatically included in resource accounting.
+- **Runtime environment**: TEE workloads run inside Kata VMs rather than standard containers. Most workloads are unaffected, but features that depend on direct host kernel access may behave differently.
+
+---
+
+## Related Topics
+
+- [Provider Confidential Compute Setup](/docs/providers/setup-and-installation/kubespray/confidential-compute) — How providers enable TEE support
+- [GPU Deployments](/docs/learn/core-concepts/gpu-deployments) — General GPU deployment guide
+- [Provider Attributes](/docs/providers/operations/provider-attributes) — How providers advertise TEE capabilities

--- a/src/content/Docs/providers/operations/confidential-compute-hardware/index.md
+++ b/src/content/Docs/providers/operations/confidential-compute-hardware/index.md
@@ -1,0 +1,68 @@
+---
+categories: ["Providers"]
+tags: ["Confidential Compute", "TEE", "Hardware", "Compatibility"]
+weight: 8
+title: "Confidential Compute Hardware Compatibility"
+linkTitle: "CC Hardware Compatibility"
+description: "Supported CPUs and GPUs for Trusted Execution Environment workloads on Akash"
+---
+
+Supported hardware for Akash Confidential Compute. Use this page to verify compatibility or plan hardware purchases.
+
+## AMD CPUs (SEV-SNP)
+
+SEV-SNP requires 3rd Gen AMD EPYC (Milan) or later.
+
+| Generation | Codename | Model Series | Notes |
+|------------|----------|-------------|-------|
+| 3rd Gen | Milan | EPYC 7003 | First generation with SEV-SNP |
+| 4th Gen | Genoa | EPYC 9004 | Zen 4 |
+| 4th Gen | Bergamo | EPYC 97x4 | Cloud-optimized Zen 4c variant |
+| 4th Gen | Siena | EPYC 82x4 | Edge/telco-optimized variant |
+| 5th Gen | Turin | EPYC 9005 | Zen 5 |
+
+Host kernel: Linux 5.19+. IOMMU must be enabled.
+
+## Intel CPUs (TDX)
+
+TDX requires 4th Gen Intel Xeon Scalable (Sapphire Rapids) or later. Not all SKUs in a generation have TDX, so check Intel ARK for your specific model.
+
+| Generation | Codename | Model Series | TDX Version |
+|------------|----------|-------------|-------------|
+| 4th Gen | Sapphire Rapids | Xeon 8400+/6400+ | 1.0 |
+| 5th Gen | Emerald Rapids | Xeon 8500+/6500+ | 1.0 |
+| 6th Gen | Granite Rapids | Xeon 6900P | 1.5 |
+| 6th Gen | Sierra Forest | Xeon 6700E/6900E | 1.5 |
+
+Host kernel: Linux 6.2+. TME must be enabled.
+
+## NVIDIA GPUs (Confidential Computing)
+
+GPU CC requires a supported GPU **and** a CC-capable CPU (SEV-SNP or TDX). Driver 535.86 or later required.
+
+| GPU | Architecture | VRAM | Form Factors |
+|-----|-------------|------|-------------|
+| H100 | Hopper | 80 GB | SXM, PCIe |
+| H200 | Hopper | 141 GB | SXM |
+| B100 | Blackwell | 192 GB | SXM |
+| B200 | Blackwell | 192 GB | SXM |
+| GB200 | Blackwell | 384 GB | NVL |
+
+> Some early H100 boards shipped with vBIOS that does not support CC. Check with your vendor for a CC-enabled vBIOS update if needed.
+
+## Compatibility Matrix
+
+| CPU | GPU | TEE Capability (SDL) | Platform | Runtime Class |
+|-----|-----|----------------------|----------|---------------|
+| AMD EPYC (Milan+) | None | `cpu` | `snp` | `kata-qemu-snp` |
+| AMD EPYC (Milan+) | Hopper/Blackwell | `cpu-gpu` | `snp` | `kata-qemu-nvidia-gpu-snp` |
+| Intel Xeon (Sapphire Rapids+) | None | `cpu` | `tdx` | `kata-qemu-tdx` |
+| Intel Xeon (Sapphire Rapids+) | Hopper/Blackwell | `cpu-gpu` | `tdx` | `kata-qemu-nvidia-gpu-tdx` |
+
+The TEE *capability* is what tenants set in SDL. The *platform* is detected by the provider from Kubernetes node labels (`intel.feature.node.kubernetes.io/tdx` or `amd.feature.node.kubernetes.io/snp`).
+
+## Related Topics
+
+- [Confidential Compute Setup](/docs/providers/setup-and-installation/kubespray/confidential-compute) — Provider TEE configuration
+- [Confidential Compute Overview](/docs/learn/core-concepts/confidential-compute) — Tenant-facing guide
+- [Provider Attributes](/docs/providers/operations/provider-attributes) — Advertise TEE capabilities

--- a/src/content/Docs/providers/operations/provider-attributes/index.md
+++ b/src/content/Docs/providers/operations/provider-attributes/index.md
@@ -665,6 +665,8 @@ attributes:
     value: "12.7"
 
   # Confidential Compute (if TEE hardware is available)
+  # - key: tee/platform
+  #   value: snp
   # - key: tee/type
   #   value: cpu
 ```

--- a/src/content/Docs/providers/operations/provider-attributes/index.md
+++ b/src/content/Docs/providers/operations/provider-attributes/index.md
@@ -473,6 +473,26 @@ Both `capabilities/ip-lease` and `feat-endpoint-ip` should be set when offering 
   value: true
 ```
 
+### tee/type
+
+- **Values**: `sev-snp`, `sev-snp-gpu`, `tdx`, `tdx-gpu`
+- **Purpose**: Advertise Trusted Execution Environment (Confidential Compute) support
+- **Required**: Only if your provider supports TEE workloads
+
+| Value | Description |
+|-------|-------------|
+| `sev-snp` | AMD SEV-SNP (CPU-only confidential VMs) |
+| `sev-snp-gpu` | AMD SEV-SNP with NVIDIA GPU Confidential Computing |
+| `tdx` | Intel TDX (CPU-only confidential VMs) |
+| `tdx-gpu` | Intel TDX with NVIDIA GPU Confidential Computing |
+
+```yaml
+- key: tee/type
+  value: sev-snp
+```
+
+> See [Confidential Compute Setup](/docs/providers/setup-and-installation/kubespray/confidential-compute) for full TEE configuration instructions.
+
 ---
 
 ## GPU Capabilities
@@ -643,6 +663,10 @@ attributes:
     value: "true"
   - key: cuda
     value: "12.7"
+
+  # Confidential Compute (if TEE hardware is available)
+  # - key: tee/type
+  #   value: sev-snp
 ```
 
 ---
@@ -663,6 +687,7 @@ Look for your attributes in the `attributes` section of the output.
 
 - [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation)
 - [GPU Support Setup](/docs/providers/setup-and-installation/kubespray/gpu-support)
+- [Confidential Compute Setup](/docs/providers/setup-and-installation/kubespray/confidential-compute) — TEE configuration guide
 - [Provider Audit](/docs/providers/operations/provider-audit) — Official audit process and attribute checklist
 - [Provider Attributes Schema](https://github.com/akash-network/console/blob/main/config/provider-attributes.json) (canonical key list)
 - [Provider Configs Repository](https://github.com/akash-network/provider-configs)

--- a/src/content/Docs/providers/operations/provider-attributes/index.md
+++ b/src/content/Docs/providers/operations/provider-attributes/index.md
@@ -475,20 +475,20 @@ Both `capabilities/ip-lease` and `feat-endpoint-ip` should be set when offering 
 
 ### tee/type
 
-- **Values**: `sev-snp`, `sev-snp-gpu`, `tdx`, `tdx-gpu`
+- **Values**: `cpu`, `cpu-gpu`
 - **Purpose**: Advertise Trusted Execution Environment (Confidential Compute) support
 - **Required**: Only if your provider supports TEE workloads
 
 | Value | Description |
 |-------|-------------|
-| `sev-snp` | AMD SEV-SNP (CPU-only confidential VMs) |
-| `sev-snp-gpu` | AMD SEV-SNP with NVIDIA GPU Confidential Computing |
-| `tdx` | Intel TDX (CPU-only confidential VMs) |
-| `tdx-gpu` | Intel TDX with NVIDIA GPU Confidential Computing |
+| `cpu` | CPU-only confidential VMs (AMD SEV-SNP or Intel TDX) |
+| `cpu-gpu` | Confidential VMs with NVIDIA GPU Confidential Computing (AMD SEV-SNP or Intel TDX) |
+
+The actual hardware platform (`snp` or `tdx`) is detected by the provider from Kubernetes node labels at runtime and is not advertised as a provider attribute.
 
 ```yaml
 - key: tee/type
-  value: sev-snp
+  value: cpu
 ```
 
 > See [Confidential Compute Setup](/docs/providers/setup-and-installation/kubespray/confidential-compute) for full TEE configuration instructions.
@@ -666,7 +666,7 @@ attributes:
 
   # Confidential Compute (if TEE hardware is available)
   # - key: tee/type
-  #   value: sev-snp
+  #   value: cpu
 ```
 
 ---

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -21,26 +21,22 @@ This guide shows how to enable Confidential Compute (TEE) support on your Akash 
 
 Confidential Compute on Akash uses [Kata Containers](https://katacontainers.io/) to run tenant workloads inside hardware-encrypted virtual machines. The provider automatically:
 
-1. Detects the TEE platform (`tdx` or `snp`) from Kubernetes node labels
-2. Matches tenant `tee/type` placement requirements against advertised provider attributes
-3. Resolves the correct Kata RuntimeClass from the requested capability and detected platform
-4. Injects an attestation sidecar into each confidential workload
-5. Proxies attestation requests from tenants to the sidecar inside the TEE
+1. Schedules TEE workloads onto nodes with the correct runtime class
+2. Injects an attestation sidecar into each confidential workload
+3. Proxies attestation requests from tenants to the sidecar inside the TEE
 
 ### Supported Configurations
 
-| TEE Capability | Detected Platform | Runtime Class | Hardware |
-|----------------|-------------------|---------------|----------|
-| `cpu` | `snp` | `kata-qemu-snp` | AMD with SEV-SNP enabled in BIOS |
-| `cpu-gpu` | `snp` | `kata-qemu-nvidia-gpu-snp` | Above + NVIDIA CC-capable GPU |
-| `cpu` | `tdx` | `kata-qemu-tdx` | Intel with TDX enabled in BIOS |
-| `cpu-gpu` | `tdx` | `kata-qemu-nvidia-gpu-tdx` | Above + NVIDIA CC-capable GPU |
+| TEE Type | Runtime Class | Hardware |
+|----------|---------------|----------|
+| AMD SEV-SNP | `kata-qemu-snp` | AMD with SEV-SNP enabled in BIOS |
+| AMD SEV-SNP + GPU | `kata-qemu-nvidia-gpu-snp` | Above + NVIDIA CC-capable GPU |
+| Intel TDX | `kata-qemu-tdx` | Intel with TDX enabled in BIOS |
+| Intel TDX + GPU | `kata-qemu-nvidia-gpu-tdx` | Above + NVIDIA CC-capable GPU |
 
 ---
 
 ## STEP 1 — Verify Hardware Support
-
-Before proceeding, confirm your hardware is on the [supported hardware list](/docs/providers/operations/confidential-compute-hardware). Not all processors in a product family support TEE, so check your specific model.
 
 ### AMD SEV-SNP
 
@@ -48,22 +44,19 @@ Run on each TEE node:
 
 ```bash
 # Check CPU supports SEV-SNP
-dmesg | grep -i sev
+dmesg | grep -i snp
 ```
 
 You should see output indicating SEV-SNP is enabled:
 
 ```
-ccp 0000:22:00.1: sev enabled
-ccp 0000:22:00.1: SEV-SNP API:1.51 build:3
-SEV supported: 410 ASIDs
-SEV-ES and SEV-SNP supported: 99 ASIDs
+SEV-SNP enabled
 ```
 
 Verify the device exists:
 
 ```bash
-ls -la /dev/sev-guest
+ls -la /dev/sev
 ```
 
 > **If SEV-SNP is not showing:** Enable it in your BIOS/UEFI under AMD CBS > CPU Configuration > SEV-SNP. Ensure your firmware is up to date.
@@ -305,7 +298,7 @@ The Akash provider automatically injects an attestation sidecar into every confi
 | Flag | Description | Required |
 |------|-------------|----------|
 | `--attestation-webhook-enabled` | Enables the Kubernetes mutating admission webhook. When active, the provider intercepts pod creation requests for confidential compute workloads and automatically injects the attestation sidecar container before scheduling. | Yes |
-| `--attestation-sidecar-image` | Docker image reference for the attestation sidecar (e.g. `ghcr.io/akash-network/attestation-sidecar:latest`). Required when the webhook is enabled, because the provider passes this image to the webhook for injection into every confidential workload. | Yes |
+| `--attestation-sidecar-image` | Docker image reference for the attestation sidecar (e.g. `ghcr.io/akash-network/attestation-sidecar:latest`). Required when the webhook is enabled — the provider passes this image to the webhook for injection into every confidential workload. | Yes |
 | `--attestation-webhook-port` | HTTPS port for the webhook server that handles Kubernetes API callbacks. In production, pair this with `--gateway-tls-cert` and `--gateway-tls-key` using a certificate whose SAN includes the provider's K8s service DNS name. Defaults to `9443` and auto-generates a self-signed cert if TLS files are omitted. | No |
 
 ### Optional Flags
@@ -339,36 +332,39 @@ provider-services run \
 
 ## STEP 6 — Configure Provider Attributes
 
-Tenants discover TEE-capable providers through on-chain attributes. Add the `tee/type` attribute to your `provider.yaml` so your provider appears in TEE-filtered searches. The value is the capability you offer; the actual hardware platform is detected from Kubernetes node labels at runtime.
+Tenants discover TEE-capable providers through on-chain attributes. Add the `tee/type` attribute to your `provider.yaml` so your provider appears in TEE-filtered searches. Set the value to the most capable TEE type your hardware supports:
 
-### CPU-only Confidential Compute
-
-```yaml
-attributes:
-  - key: tee/type
-    value: cpu
-```
-
-### Confidential Compute with GPU
+### AMD SEV-SNP (CPU only)
 
 ```yaml
 attributes:
   - key: tee/type
-    value: cpu-gpu
+    value: sev-snp
 ```
 
-### Node Labels for Platform Detection
+### AMD SEV-SNP + GPU
 
-The provider determines whether it runs on Intel TDX or AMD SEV-SNP by reading Kubernetes node labels:
+```yaml
+attributes:
+  - key: tee/type
+    value: sev-snp-gpu
+```
 
-- `intel.feature.node.kubernetes.io/tdx=true` — Intel TDX
-- `amd.feature.node.kubernetes.io/snp=true` — AMD SEV-SNP
+### Intel TDX (CPU only)
 
-These labels are set by the Kubernetes node-feature-discovery (NFD) component and do **not** need to be advertised as provider attributes.
+```yaml
+attributes:
+  - key: tee/type
+    value: tdx
+```
 
-### GPU Resources
+### Intel TDX + GPU
 
-For `cpu-gpu` workloads, the provider schedules NVIDIA GPUs using the VFIO-passthrough resource `nvidia.com/pgpu`. This resource is exposed by the kata-sandbox-device-plugin and is separate from the standard `nvidia.com/gpu` resource used for non-CC GPU workloads.
+```yaml
+attributes:
+  - key: tee/type
+    value: tdx-gpu
+```
 
 After updating attributes, restart your provider:
 
@@ -401,7 +397,8 @@ services:
         to:
           - global: true
     params:
-      tee: cpu
+      tee:
+        type: sev-snp
 
 profiles:
   compute:
@@ -412,7 +409,7 @@ profiles:
         memory:
           size: 256Mi
         storage:
-          size: 256Mi
+          size: 128Mi
   placement:
     akash:
       pricing:
@@ -435,7 +432,7 @@ provider-services tx deployment create test-cc.yaml --from <your-key>
 
 # After lease is created, check that the pod has the correct runtime class
 kubectl get pods -n <lease-namespace> -o jsonpath='{.items[0].spec.runtimeClassName}'
-# Expected: kata-qemu-snp or kata-qemu-tdx, depending on provider hardware
+# Expected: kata-qemu-snp
 
 # Check the attestation sidecar was injected
 kubectl get pods -n <lease-namespace> -o jsonpath='{.items[0].spec.containers[*].name}'
@@ -499,8 +496,8 @@ Common causes:
 
 ## Related Topics
 
-- [CC Hardware Compatibility](/docs/providers/operations/confidential-compute-hardware) — Supported CPUs and GPUs for Confidential Compute
 - [Confidential Compute Overview](/docs/learn/core-concepts/confidential-compute) — Tenant-facing guide for deploying confidential workloads
+- [SDL Advanced Features](/docs/developers/deployment/akash-sdl/advanced-features) — SDL reference for TEE configuration
 - [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support) — Enable GPU resources on your provider
 - [Provider Attributes](/docs/providers/operations/provider-attributes) — Advertise provider capabilities
-- [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation) — Base provider setup
+- [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation) - Base provider setup

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -1,0 +1,510 @@
+---
+categories: ["Providers"]
+tags: ["Confidential Compute", "TEE", "Advanced Features", "Configuration"]
+weight: 3
+title: "Confidential Compute (TEE) Support"
+linkTitle: "Confidential Compute"
+description: "Enable Trusted Execution Environment support on your Akash provider"
+---
+
+This guide shows how to enable Confidential Compute (TEE) support on your Akash provider, allowing tenants to deploy workloads inside hardware-backed Trusted Execution Environments.
+
+> **Prerequisites:** You must have a working Akash provider with Kubernetes already deployed. See [Kubernetes Setup](/docs/providers/setup-and-installation/kubespray/kubernetes-setup) and [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation).
+
+> **Hardware required:** Your nodes must have TEE-capable processors, AMD EPYC (Milan or later) for SEV-SNP, or Intel Xeon (Sapphire Rapids or later) for TDX.
+
+> **Do not enable LUKS (full-disk encryption) on TEE host nodes.** SEV-SNP and TDX encrypt guest VM memory at the hardware level, that is the security boundary that matters for tenant workloads. LUKS on the host root filesystem adds boot-time complexity without providing additional protection.
+
+---
+
+## Overview
+
+Confidential Compute on Akash uses [Kata Containers](https://katacontainers.io/) to run tenant workloads inside hardware-encrypted virtual machines. The provider automatically:
+
+1. Schedules TEE workloads onto nodes with the correct runtime class
+2. Injects an attestation sidecar into each confidential workload
+3. Proxies attestation requests from tenants to the sidecar inside the TEE
+
+### Supported Configurations
+
+| TEE Type | Runtime Class | Hardware |
+|----------|---------------|----------|
+| AMD SEV-SNP | `kata-qemu-snp` | AMD with SEV-SNP enabled in BIOS |
+| AMD SEV-SNP + GPU | `kata-qemu-nvidia-gpu-snp` | Above + NVIDIA CC-capable GPU |
+| Intel TDX | `kata-qemu-tdx` | Intel with TDX enabled in BIOS |
+| Intel TDX + GPU | `kata-qemu-nvidia-gpu-tdx` | Above + NVIDIA CC-capable GPU |
+
+---
+
+## STEP 1 — Verify Hardware Support
+
+### AMD SEV-SNP
+
+Run on each TEE node:
+
+```bash
+# Check CPU supports SEV-SNP
+dmesg | grep -i sev
+```
+
+You should see output indicating SEV-SNP is enabled:
+
+```
+ccp 0000:22:00.1: sev enabled
+ccp 0000:22:00.1: SEV-SNP API:1.51 build:3
+SEV supported: 410 ASIDs
+SEV-ES and SEV-SNP supported: 99 ASIDs
+```
+
+Verify the device exists:
+
+```bash
+ls -la /dev/sev-guest
+```
+
+> **If SEV-SNP is not showing:** Enable it in your BIOS/UEFI under AMD CBS > CPU Configuration > SEV-SNP. Ensure your firmware is up to date.
+
+### Intel TDX
+
+Run on each TEE node:
+
+```bash
+# Check CPU supports TDX
+dmesg | grep -i tdx
+```
+
+You should see:
+
+```
+tdx: TDX module initialized
+virt/tdx: module initialized
+```
+
+Verify the device exists:
+
+```bash
+ls -la /dev/tdx_guest  # or /dev/tdx-attest on older kernels
+```
+
+> **If TDX is not showing:** Enable it in your BIOS/UEFI under Intel Advanced Menu > TDX. Requires a TDX-capable kernel (Linux 6.2+).
+
+---
+
+## STEP 2 — Install Kata Containers
+
+Once hardware support is confirmed, install the [Kata Containers](https://katacontainers.io/) runtime. Kata runs each confidential workload inside a lightweight VM with hardware-encrypted memory. Install it on **each TEE node**.
+
+### Install Kata Packages
+
+```bash
+# Add Kata Containers repository
+sudo mkdir -p /etc/apt/keyrings
+wget -qO- https://packagecloud.io/kata-containers/stable/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kata-containers.gpg
+echo "deb [signed-by=/etc/apt/keyrings/kata-containers.gpg] https://packagecloud.io/kata-containers/stable/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/kata-containers.list
+
+sudo apt update
+sudo apt install -y kata-containers
+```
+
+### Configure Kata for Your TEE Type
+
+#### AMD SEV-SNP Configuration
+
+Create the Kata configuration for SNP at `/etc/kata-containers/configuration-qemu-snp.toml`:
+
+```toml
+[hypervisor.qemu]
+path = "/usr/bin/qemu-system-x86_64"
+kernel = "/usr/share/kata-containers/vmlinuz-snp.container"
+image = "/usr/share/kata-containers/kata-containers-snp.img"
+machine_type = "q35"
+firmware = "/usr/share/OVMF/OVMF_CODE.fd"
+confidential_guest = true
+sev_snp_guest = true
+
+default_memory = 256
+default_vcpus = 1
+
+[runtime]
+enable_annotations = ["io.katacontainers.*"]
+sandbox_cgroup_only = true
+```
+
+#### Intel TDX Configuration
+
+Create the Kata configuration for TDX at `/etc/kata-containers/configuration-qemu-tdx.toml`:
+
+```toml
+[hypervisor.qemu]
+path = "/usr/bin/qemu-system-x86_64"
+kernel = "/usr/share/kata-containers/vmlinuz-tdx.container"
+image = "/usr/share/kata-containers/kata-containers-tdx.img"
+machine_type = "q35"
+firmware = "/usr/share/OVMF/OVMF_CODE.fd"
+confidential_guest = true
+tdx_guest = true
+
+default_memory = 256
+default_vcpus = 1
+
+[runtime]
+enable_annotations = ["io.katacontainers.*"]
+sandbox_cgroup_only = true
+```
+
+---
+
+## STEP 3 — Configure Containerd Runtime Classes
+
+Containerd needs to know about the Kata runtime classes so it can launch confidential VMs. Add the entries below to `/etc/containerd/config.toml` on **each TEE node**. Only add the runtime classes that match your hardware.
+
+### AMD SEV-SNP
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-snp]
+  runtime_type = "io.containerd.kata-qemu-snp.v2"
+  privileged_without_host_devices = true
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-snp.options]
+    ConfigPath = "/etc/kata-containers/configuration-qemu-snp.toml"
+```
+
+For SNP with GPU support, add:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-nvidia-gpu-snp]
+  runtime_type = "io.containerd.kata-qemu-nvidia-gpu-snp.v2"
+  privileged_without_host_devices = true
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-nvidia-gpu-snp.options]
+    ConfigPath = "/etc/kata-containers/configuration-qemu-nvidia-gpu-snp.toml"
+```
+
+### Intel TDX
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-tdx]
+  runtime_type = "io.containerd.kata-qemu-tdx.v2"
+  privileged_without_host_devices = true
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-tdx.options]
+    ConfigPath = "/etc/kata-containers/configuration-qemu-tdx.toml"
+```
+
+For TDX with GPU support, add:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-nvidia-gpu-tdx]
+  runtime_type = "io.containerd.kata-qemu-nvidia-gpu-tdx.v2"
+  privileged_without_host_devices = true
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-nvidia-gpu-tdx.options]
+    ConfigPath = "/etc/kata-containers/configuration-qemu-nvidia-gpu-tdx.toml"
+```
+
+Restart containerd after configuration changes:
+
+```bash
+sudo systemctl restart containerd
+```
+
+---
+
+## STEP 4 — Create Kubernetes RuntimeClasses
+
+Kubernetes uses [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) resources to map workloads to specific container runtimes. Create one for each TEE type your provider supports. Only create the ones that match your hardware, you do not need all four.
+
+### AMD SEV-SNP
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu-snp
+handler: kata-qemu-snp
+overhead:
+  podFixed:
+    memory: "160Mi"
+    cpu: "250m"
+EOF
+```
+
+For SNP with GPU:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu-nvidia-gpu-snp
+handler: kata-qemu-nvidia-gpu-snp
+overhead:
+  podFixed:
+    memory: "160Mi"
+    cpu: "250m"
+EOF
+```
+
+### Intel TDX
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu-tdx
+handler: kata-qemu-tdx
+overhead:
+  podFixed:
+    memory: "160Mi"
+    cpu: "250m"
+EOF
+```
+
+For TDX with GPU:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu-nvidia-gpu-tdx
+handler: kata-qemu-nvidia-gpu-tdx
+overhead:
+  podFixed:
+    memory: "160Mi"
+    cpu: "250m"
+EOF
+```
+
+### Verify RuntimeClasses
+
+```bash
+kubectl get runtimeclass
+```
+
+Expected output (depending on which TEE types you configured):
+
+```
+NAME                         HANDLER                      AGE
+kata-qemu-snp                kata-qemu-snp                1m
+kata-qemu-nvidia-gpu-snp     kata-qemu-nvidia-gpu-snp     1m
+kata-qemu-tdx                kata-qemu-tdx                1m
+kata-qemu-nvidia-gpu-tdx     kata-qemu-nvidia-gpu-tdx     1m
+```
+
+---
+
+## STEP 5 — Configure Provider Flags
+
+The Akash provider automatically injectw an attestation sidecar into every confidential workload if requested by the user. This sidecar runs inside the TEE and serves hardware-signed attestation reports to tenants. Enable it with the following flags.
+
+### Required Flags
+
+| Flag | Description | Required |
+|------|-------------|----------|
+| `--attestation-webhook-enabled` | Enables the Kubernetes mutating admission webhook. When active, the provider intercepts pod creation requests for confidential compute workloads and automatically injects the attestation sidecar container before scheduling. | Yes |
+| `--attestation-sidecar-image` | Docker image reference for the attestation sidecar (e.g. `ghcr.io/akash-network/attestation-sidecar:latest`). Required when the webhook is enabled — the provider passes this image to the webhook for injection into every confidential workload. | Yes |
+| `--attestation-webhook-port` | HTTPS port for the webhook server that handles Kubernetes API callbacks. In production, pair this with `--gateway-tls-cert` and `--gateway-tls-key` using a certificate whose SAN includes the provider's K8s service DNS name. Defaults to `9443` and auto-generates a self-signed cert if TLS files are omitted. | No |
+
+### Optional Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--attestation-expected-measurement` | Hex-encoded expected AMD SEV-SNP launch measurement. Returned as an **advisory hint only** by the provider's directory endpoint. The provider does not verify this value against hardware, tenants must independently fetch the hardware-signed SNP report from the sidecar and compare the `MEASUREMENT` field themselves. Do not treat this as a trust signal. | Empty |
+| `--attestation-expected-image-digest` | Expected digest of the Kata VM image. Like the measurement flag, this is an **untrusted advisory hint** surfaced in the directory response for tenant convenience. Tenants should verify the actual image digest through their own trusted channels. | Empty |
+| `--attestation-mock` | Run the sidecar in mock mode with synthetic (fake) attestation reports instead of real TEE hardware evidence. Also switches the webhook registration to a `host.docker.internal` URL for local clusters. **For local development only, never enable in production.** | `false` |
+
+### Example: Helm Values
+
+When deploying the provider with Helm, add these values:
+
+```yaml
+# provider.yaml
+attestation:
+  webhookEnabled: true
+  sidecarImage: "ghcr.io/akash-network/attestation-sidecar:latest"
+  webhookPort: 9443
+  # Optional advisory hints
+  # expectedMeasurement: "<hex-encoded-measurement>"
+  # expectedImageDigest: "<kata-vm-image-digest>"
+```
+
+### Example: CLI Flags
+
+```bash
+provider-services run \
+  --attestation-webhook-enabled \
+  --attestation-sidecar-image "ghcr.io/akash-network/attestation-sidecar:latest" \
+  --attestation-webhook-port 9443
+```
+
+---
+
+## STEP 6 — Configure Provider Attributes
+
+Tenants discover TEE-capable providers through on-chain attributes. Add the `tee/type` attribute to your `provider.yaml` so your provider appears in TEE-filtered searches. Set the value to the most capable TEE type your hardware supports:
+
+### AMD SEV-SNP (CPU only)
+
+```yaml
+attributes:
+  - key: tee/type
+    value: sev-snp
+```
+
+### AMD SEV-SNP + GPU
+
+```yaml
+attributes:
+  - key: tee/type
+    value: sev-snp-gpu
+```
+
+### Intel TDX (CPU only)
+
+```yaml
+attributes:
+  - key: tee/type
+    value: tdx
+```
+
+### Intel TDX + GPU
+
+```yaml
+attributes:
+  - key: tee/type
+    value: tdx-gpu
+```
+
+After updating attributes, restart your provider:
+
+```bash
+cd /root/provider
+helm upgrade akash-provider akash/provider \
+  -n akash-services \
+  -f provider.yaml \
+  --set bidpricescript="$(cat price_script.sh | openssl base64 -A)"
+```
+
+---
+
+## STEP 7 — Verify Setup
+
+### Test with a Confidential Deployment
+
+Create a test SDL file (`test-cc.yaml`):
+
+```yaml
+---
+version: "2.1"
+
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+    params:
+      tee:
+        type: sev-snp
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 256Mi
+        storage:
+          size: 128Mi
+  placement:
+    akash:
+      pricing:
+        web:
+          denom: uact
+          amount: 1000
+
+deployment:
+  web:
+    akash:
+      profile: web
+      count: 1
+```
+
+Deploy and verify:
+
+```bash
+# Deploy
+provider-services tx deployment create test-cc.yaml --from <your-key>
+
+# After lease is created, check that the pod has the correct runtime class
+kubectl get pods -n <lease-namespace> -o jsonpath='{.items[0].spec.runtimeClassName}'
+# Expected: kata-qemu-snp
+
+# Check the attestation sidecar was injected
+kubectl get pods -n <lease-namespace> -o jsonpath='{.items[0].spec.containers[*].name}'
+# Expected: web akash-attestation-sidecar
+```
+
+### Request an Attestation Quote
+
+```bash
+provider-services lease-attestation \
+  --dseq <deployment-sequence> \
+  --gseq 1 \
+  --oseq 1 \
+  --provider <provider-address> \
+  --from <your-key>
+```
+
+A successful response contains a hardware-signed attestation report, confirming the workload is running in a genuine TEE.
+
+---
+
+## Troubleshooting
+
+### Pod stuck in Pending
+
+```bash
+kubectl describe pod <pod-name> -n <lease-namespace>
+```
+
+Common causes:
+- **RuntimeClass not found**: Verify the RuntimeClass exists with `kubectl get runtimeclass`
+- **No TEE-capable nodes**: Ensure nodes with TEE hardware are labeled and schedulable
+- **Kata not installed**: Check that Kata is properly installed on the target node
+
+### Attestation sidecar not injected
+
+- Verify the webhook is running: `kubectl get mutatingwebhookconfigurations`
+- Check provider logs for webhook errors
+- Ensure `--attestation-webhook-enabled` is set
+
+### Attestation quote returns error
+
+- Verify the sidecar container is running: `kubectl logs <pod> -c akash-attestation-sidecar -n <namespace>`
+- Check that TEE devices are accessible inside the Kata VM
+- For GPU variants, verify NVIDIA drivers are available inside the guest
+
+### SEV-SNP device not found
+
+- Ensure BIOS has SEV-SNP enabled
+- Update to latest firmware/microcode
+- Verify kernel supports SEV-SNP (Linux 5.19+)
+- Check `dmesg | grep -i sev` for errors
+
+### TDX device not found
+
+- Ensure BIOS has TDX enabled
+- Verify TDX kernel module is loaded: `lsmod | grep tdx`
+- TDX requires Linux 6.2+ with TDX support compiled in
+
+---
+
+## Related Topics
+
+- [Confidential Compute Overview](/docs/learn/core-concepts/confidential-compute) - Tenant-facing guide for deploying confidential workloads
+- [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support) - Enable GPU resources on your provider
+- [Provider Attributes](/docs/providers/operations/provider-attributes) - Advertise provider capabilities
+- [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation) - Base provider setup

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -298,7 +298,7 @@ kata-qemu-nvidia-gpu-tdx     kata-qemu-nvidia-gpu-tdx     1m
 
 ## STEP 5 — Configure Provider Flags
 
-The Akash provider automatically injectw an attestation sidecar into every confidential workload if requested by the user. This sidecar runs inside the TEE and serves hardware-signed attestation reports to tenants. Enable it with the following flags.
+The Akash provider automatically injects an attestation sidecar into every confidential workload if requested by the user. This sidecar runs inside the TEE and serves hardware-signed attestation reports to tenants. Enable it with the following flags.
 
 ### Required Flags
 

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -21,22 +21,26 @@ This guide shows how to enable Confidential Compute (TEE) support on your Akash 
 
 Confidential Compute on Akash uses [Kata Containers](https://katacontainers.io/) to run tenant workloads inside hardware-encrypted virtual machines. The provider automatically:
 
-1. Schedules TEE workloads onto nodes with the correct runtime class
-2. Injects an attestation sidecar into each confidential workload
-3. Proxies attestation requests from tenants to the sidecar inside the TEE
+1. Detects the TEE platform (`tdx` or `snp`) from Kubernetes node labels
+2. Matches tenant `tee/type` placement requirements against advertised provider attributes
+3. Resolves the correct Kata RuntimeClass from the requested capability and detected platform
+4. Injects an attestation sidecar into each confidential workload
+5. Proxies attestation requests from tenants to the sidecar inside the TEE
 
 ### Supported Configurations
 
-| TEE Type | Runtime Class | Hardware |
-|----------|---------------|----------|
-| AMD SEV-SNP | `kata-qemu-snp` | AMD with SEV-SNP enabled in BIOS |
-| AMD SEV-SNP + GPU | `kata-qemu-nvidia-gpu-snp` | Above + NVIDIA CC-capable GPU |
-| Intel TDX | `kata-qemu-tdx` | Intel with TDX enabled in BIOS |
-| Intel TDX + GPU | `kata-qemu-nvidia-gpu-tdx` | Above + NVIDIA CC-capable GPU |
+| TEE Capability | Detected Platform | Runtime Class | Hardware |
+|----------------|-------------------|---------------|----------|
+| `cpu` | `snp` | `kata-qemu-snp` | AMD with SEV-SNP enabled in BIOS |
+| `cpu-gpu` | `snp` | `kata-qemu-nvidia-gpu-snp` | Above + NVIDIA CC-capable GPU |
+| `cpu` | `tdx` | `kata-qemu-tdx` | Intel with TDX enabled in BIOS |
+| `cpu-gpu` | `tdx` | `kata-qemu-nvidia-gpu-tdx` | Above + NVIDIA CC-capable GPU |
 
 ---
 
 ## STEP 1 — Verify Hardware Support
+
+Before proceeding, confirm your hardware is on the [supported hardware list](/docs/providers/operations/confidential-compute-hardware). Not all processors in a product family support TEE, so check your specific model.
 
 ### AMD SEV-SNP
 
@@ -301,7 +305,7 @@ The Akash provider automatically injectw an attestation sidecar into every confi
 | Flag | Description | Required |
 |------|-------------|----------|
 | `--attestation-webhook-enabled` | Enables the Kubernetes mutating admission webhook. When active, the provider intercepts pod creation requests for confidential compute workloads and automatically injects the attestation sidecar container before scheduling. | Yes |
-| `--attestation-sidecar-image` | Docker image reference for the attestation sidecar (e.g. `ghcr.io/akash-network/attestation-sidecar:latest`). Required when the webhook is enabled — the provider passes this image to the webhook for injection into every confidential workload. | Yes |
+| `--attestation-sidecar-image` | Docker image reference for the attestation sidecar (e.g. `ghcr.io/akash-network/attestation-sidecar:latest`). Required when the webhook is enabled, because the provider passes this image to the webhook for injection into every confidential workload. | Yes |
 | `--attestation-webhook-port` | HTTPS port for the webhook server that handles Kubernetes API callbacks. In production, pair this with `--gateway-tls-cert` and `--gateway-tls-key` using a certificate whose SAN includes the provider's K8s service DNS name. Defaults to `9443` and auto-generates a self-signed cert if TLS files are omitted. | No |
 
 ### Optional Flags
@@ -320,7 +324,6 @@ attestation:
   webhookEnabled: true
   sidecarImage: "ghcr.io/akash-network/attestation-sidecar:latest"
   webhookPort: 9443
-  # Optional advisory hints
 ```
 
 ### Example: CLI Flags
@@ -336,39 +339,36 @@ provider-services run \
 
 ## STEP 6 — Configure Provider Attributes
 
-Tenants discover TEE-capable providers through on-chain attributes. Add the `tee/type` attribute to your `provider.yaml` so your provider appears in TEE-filtered searches. Set the value to the most capable TEE type your hardware supports:
+Tenants discover TEE-capable providers through on-chain attributes. Add the `tee/type` attribute to your `provider.yaml` so your provider appears in TEE-filtered searches. The value is the capability you offer; the actual hardware platform is detected from Kubernetes node labels at runtime.
 
-### AMD SEV-SNP (CPU only)
-
-```yaml
-attributes:
-  - key: tee/type
-    value: sev-snp
-```
-
-### AMD SEV-SNP + GPU
+### CPU-only Confidential Compute
 
 ```yaml
 attributes:
   - key: tee/type
-    value: sev-snp-gpu
+    value: cpu
 ```
 
-### Intel TDX (CPU only)
+### Confidential Compute with GPU
 
 ```yaml
 attributes:
   - key: tee/type
-    value: tdx
+    value: cpu-gpu
 ```
 
-### Intel TDX + GPU
+### Node Labels for Platform Detection
 
-```yaml
-attributes:
-  - key: tee/type
-    value: tdx-gpu
-```
+The provider determines whether it runs on Intel TDX or AMD SEV-SNP by reading Kubernetes node labels:
+
+- `intel.feature.node.kubernetes.io/tdx=true` — Intel TDX
+- `amd.feature.node.kubernetes.io/snp=true` — AMD SEV-SNP
+
+These labels are set by the Kubernetes node-feature-discovery (NFD) component and do **not** need to be advertised as provider attributes.
+
+### GPU Resources
+
+For `cpu-gpu` workloads, the provider schedules NVIDIA GPUs using the VFIO-passthrough resource `nvidia.com/pgpu`. This resource is exposed by the kata-sandbox-device-plugin and is separate from the standard `nvidia.com/gpu` resource used for non-CC GPU workloads.
 
 After updating attributes, restart your provider:
 
@@ -401,8 +401,7 @@ services:
         to:
           - global: true
     params:
-      tee:
-        type: sev-snp
+      tee: cpu
 
 profiles:
   compute:
@@ -413,7 +412,7 @@ profiles:
         memory:
           size: 256Mi
         storage:
-          size: 128Mi
+          size: 256Mi
   placement:
     akash:
       pricing:
@@ -436,7 +435,7 @@ provider-services tx deployment create test-cc.yaml --from <your-key>
 
 # After lease is created, check that the pod has the correct runtime class
 kubectl get pods -n <lease-namespace> -o jsonpath='{.items[0].spec.runtimeClassName}'
-# Expected: kata-qemu-snp
+# Expected: kata-qemu-snp or kata-qemu-tdx, depending on provider hardware
 
 # Check the attestation sidecar was injected
 kubectl get pods -n <lease-namespace> -o jsonpath='{.items[0].spec.containers[*].name}'
@@ -500,8 +499,8 @@ Common causes:
 
 ## Related Topics
 
+- [CC Hardware Compatibility](/docs/providers/operations/confidential-compute-hardware) — Supported CPUs and GPUs for Confidential Compute
 - [Confidential Compute Overview](/docs/learn/core-concepts/confidential-compute) — Tenant-facing guide for deploying confidential workloads
-- [SDL Advanced Features](/docs/developers/deployment/akash-sdl/advanced-features) — SDL reference for TEE configuration
 - [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support) — Enable GPU resources on your provider
 - [Provider Attributes](/docs/providers/operations/provider-attributes) — Advertise provider capabilities
-- [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation) - Base provider setup
+- [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation) — Base provider setup

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -308,8 +308,6 @@ The Akash provider automatically injectw an attestation sidecar into every confi
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--attestation-expected-measurement` | Hex-encoded expected AMD SEV-SNP launch measurement. Returned as an **advisory hint only** by the provider's directory endpoint. The provider does not verify this value against hardware, tenants must independently fetch the hardware-signed SNP report from the sidecar and compare the `MEASUREMENT` field themselves. Do not treat this as a trust signal. | Empty |
-| `--attestation-expected-image-digest` | Expected digest of the Kata VM image. Like the measurement flag, this is an **untrusted advisory hint** surfaced in the directory response for tenant convenience. Tenants should verify the actual image digest through their own trusted channels. | Empty |
 | `--attestation-mock` | Run the sidecar in mock mode with synthetic (fake) attestation reports instead of real TEE hardware evidence. Also switches the webhook registration to a `host.docker.internal` URL for local clusters. **For local development only, never enable in production.** | `false` |
 
 ### Example: Helm Values
@@ -323,8 +321,6 @@ attestation:
   sidecarImage: "ghcr.io/akash-network/attestation-sidecar:latest"
   webhookPort: 9443
   # Optional advisory hints
-  # expectedMeasurement: "<hex-encoded-measurement>"
-  # expectedImageDigest: "<kata-vm-image-digest>"
 ```
 
 ### Example: CLI Flags

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -87,209 +87,90 @@ ls -la /dev/tdx_guest  # or /dev/tdx-attest on older kernels
 
 ---
 
-## STEP 2 — Install Kata Containers
+## STEP 2 — Install Kata Containers via kata-deploy
 
-Once hardware support is confirmed, install the [Kata Containers](https://katacontainers.io/) runtime. Kata runs each confidential workload inside a lightweight VM with hardware-encrypted memory. Install it on **each TEE node**.
+[Kata Containers](https://katacontainers.io/) provides the confidential VM runtime. Install it using the `kata-deploy` Helm chart, which configures containerd runtime classes, RuntimeClass resources, and all Kata binaries automatically.
 
-### Install Kata Packages
-
-```bash
-# Add Kata Containers repository
-sudo mkdir -p /etc/apt/keyrings
-wget -qO- https://packagecloud.io/kata-containers/stable/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kata-containers.gpg
-echo "deb [signed-by=/etc/apt/keyrings/kata-containers.gpg] https://packagecloud.io/kata-containers/stable/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/kata-containers.list
-
-sudo apt update
-sudo apt install -y kata-containers
-```
-
-### Configure Kata for Your TEE Type
-
-#### AMD SEV-SNP Configuration
-
-Create the Kata configuration for SNP at `/etc/kata-containers/configuration-qemu-snp.toml`:
-
-```toml
-[hypervisor.qemu]
-path = "/usr/bin/qemu-system-x86_64"
-kernel = "/usr/share/kata-containers/vmlinuz-snp.container"
-image = "/usr/share/kata-containers/kata-containers-snp.img"
-machine_type = "q35"
-firmware = "/usr/share/OVMF/OVMF_CODE.fd"
-confidential_guest = true
-sev_snp_guest = true
-
-default_memory = 256
-default_vcpus = 1
-
-[runtime]
-enable_annotations = ["io.katacontainers.*"]
-sandbox_cgroup_only = true
-```
-
-#### Intel TDX Configuration
-
-Create the Kata configuration for TDX at `/etc/kata-containers/configuration-qemu-tdx.toml`:
-
-```toml
-[hypervisor.qemu]
-path = "/usr/bin/qemu-system-x86_64"
-kernel = "/usr/share/kata-containers/vmlinuz-tdx.container"
-image = "/usr/share/kata-containers/kata-containers-tdx.img"
-machine_type = "q35"
-firmware = "/usr/share/OVMF/OVMF_CODE.fd"
-confidential_guest = true
-tdx_guest = true
-
-default_memory = 256
-default_vcpus = 1
-
-[runtime]
-enable_annotations = ["io.katacontainers.*"]
-sandbox_cgroup_only = true
-```
-
----
-
-## STEP 3 — Configure Containerd Runtime Classes
-
-Containerd needs to know about the Kata runtime classes so it can launch confidential VMs. Add the entries below to `/etc/containerd/config.toml` on **each TEE node**. Only add the runtime classes that match your hardware.
-
-### AMD SEV-SNP
-
-```toml
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-snp]
-  runtime_type = "io.containerd.kata-qemu-snp.v2"
-  privileged_without_host_devices = true
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-snp.options]
-    ConfigPath = "/etc/kata-containers/configuration-qemu-snp.toml"
-```
-
-For SNP with GPU support, add:
-
-```toml
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-nvidia-gpu-snp]
-  runtime_type = "io.containerd.kata-qemu-nvidia-gpu-snp.v2"
-  privileged_without_host_devices = true
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-nvidia-gpu-snp.options]
-    ConfigPath = "/etc/kata-containers/configuration-qemu-nvidia-gpu-snp.toml"
-```
-
-### Intel TDX
-
-```toml
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-tdx]
-  runtime_type = "io.containerd.kata-qemu-tdx.v2"
-  privileged_without_host_devices = true
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-tdx.options]
-    ConfigPath = "/etc/kata-containers/configuration-qemu-tdx.toml"
-```
-
-For TDX with GPU support, add:
-
-```toml
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-nvidia-gpu-tdx]
-  runtime_type = "io.containerd.kata-qemu-nvidia-gpu-tdx.v2"
-  privileged_without_host_devices = true
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-nvidia-gpu-tdx.options]
-    ConfigPath = "/etc/kata-containers/configuration-qemu-nvidia-gpu-tdx.toml"
-```
-
-Restart containerd after configuration changes:
+> **Do not install** QEMU, KVM userspace, libvirt, or OVMF packages on the host. Kata ships its own NVIDIA-patched versions of these components. Pre-installing them creates silent conflicts.
 
 ```bash
-sudo systemctl restart containerd
+helm install kata-deploy \
+  oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
+  --namespace kata-system --create-namespace \
+  --set nfd.enabled=false \
+  --wait --timeout 10m \
+  --version 3.29.0
 ```
 
----
+> If running K3s instead of standard Kubernetes, add `--set k8sDistribution=k3s`. Without this flag, kata-deploy will fail searching for containerd config at the wrong path.
 
-## STEP 4 — Create Kubernetes RuntimeClasses
-
-Kubernetes uses [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) resources to map workloads to specific container runtimes. Create one for each TEE type your provider supports. Only create the ones that match your hardware, you do not need all four.
-
-### AMD SEV-SNP
+Verify the installation:
 
 ```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata:
-  name: kata-qemu-snp
-handler: kata-qemu-snp
-overhead:
-  podFixed:
-    memory: "160Mi"
-    cpu: "250m"
-EOF
+# kata-deploy pod should be Running
+kubectl get pods -n kata-system
+
+# RuntimeClasses should be created automatically
+kubectl get runtimeclass | grep kata-qemu
 ```
 
-For SNP with GPU:
+You should see runtime classes including `kata-qemu-snp`, `kata-qemu-tdx`, and their GPU variants (`kata-qemu-nvidia-gpu-snp`, `kata-qemu-nvidia-gpu-tdx`).
+
+## STEP 3 — Install NVIDIA GPU Operator (GPU providers only)
+
+> Skip this step if your provider does not offer GPU Confidential Computing.
+
+The NVIDIA GPU Operator handles GPU VFIO binding, CC mode toggling, and device plugin registration. Do **not** install NVIDIA GPU drivers on the host — the operator manages everything.
 
 ```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata:
-  name: kata-qemu-nvidia-gpu-snp
-handler: kata-qemu-nvidia-gpu-snp
-overhead:
-  podFixed:
-    memory: "160Mi"
-    cpu: "250m"
-EOF
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+helm repo update
+
+helm install gpu-operator nvidia/gpu-operator \
+  --namespace gpu-operator --create-namespace \
+  --version v26.3.1 \
+  --set sandboxWorkloads.enabled=true \
+  --set sandboxWorkloads.mode=kata \
+  --set nfd.enabled=true \
+  --set nfd.nodefeaturerules=true \
+  --wait --timeout 10m
 ```
 
-### Intel TDX
+Label each GPU node for operand activation:
 
 ```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata:
-  name: kata-qemu-tdx
-handler: kata-qemu-tdx
-overhead:
-  podFixed:
-    memory: "160Mi"
-    cpu: "250m"
-EOF
+kubectl label node <node-name> nvidia.com/gpu.workload.config=vm-passthrough
 ```
 
-For TDX with GPU:
+Verify the installation:
 
 ```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata:
-  name: kata-qemu-nvidia-gpu-tdx
-handler: kata-qemu-nvidia-gpu-tdx
-overhead:
-  podFixed:
-    memory: "160Mi"
-    cpu: "250m"
-EOF
+# All operand pods should be Running
+kubectl get pods -n gpu-operator
+
+# GPU should be bound to vfio-pci (not nvidia driver)
+lspci -nnk -d 10de: | grep "Kernel driver in use"
+# Expected: vfio-pci
+
+# CC mode should be enabled
+kubectl get node <node-name> -o json | \
+  jq '.metadata.labels | with_entries(select(.key | startswith("nvidia.com/cc")))'
+# Expected: "nvidia.com/cc.mode.state": "on", "nvidia.com/cc.ready.state": "true"
+
+# Passthrough GPU resource should be advertised
+kubectl get node <node-name> -o json | \
+  jq '.status.allocatable | with_entries(select(.key | startswith("nvidia.com")))'
+# Expected: "nvidia.com/pgpu": "1" (or more, depending on GPU count)
 ```
 
-### Verify RuntimeClasses
+The operator deploys several components:
+- **nvidia-vfio-manager** — binds GPUs to the `vfio-pci` driver for passthrough
+- **nvidia-cc-manager** — toggles GPU Confidential Computing mode (default: on)
+- **nvidia-kata-sandbox-device-plugin** — advertises `nvidia.com/pgpu` resources
+- **nvidia-sandbox-validator** — node-level CC readiness validation
+- **NFD components** — detects CPU TEE capabilities and GPU presence via node labels
 
-```bash
-kubectl get runtimeclass
-```
-
-Expected output (depending on which TEE types you configured):
-
-```
-NAME                         HANDLER                      AGE
-kata-qemu-snp                kata-qemu-snp                1m
-kata-qemu-nvidia-gpu-snp     kata-qemu-nvidia-gpu-snp     1m
-kata-qemu-tdx                kata-qemu-tdx                1m
-kata-qemu-nvidia-gpu-tdx     kata-qemu-nvidia-gpu-tdx     1m
-```
-
----
-
-## STEP 5 — Configure Provider Flags
+## STEP 4 — Configure Provider Flags
 
 The Akash provider automatically injects an attestation sidecar into every confidential workload if requested by the user. This sidecar runs inside the TEE and serves hardware-signed attestation reports to tenants. Enable it with the following flags.
 
@@ -330,7 +211,7 @@ provider-services run \
 
 ---
 
-## STEP 6 — Configure Provider Attributes
+## STEP 5 — Configure Provider Attributes
 
 Tenants discover TEE-capable providers through on-chain attributes. Add the `tee/type` attribute to your `provider.yaml` so your provider appears in TEE-filtered searches. Set the value to the most capable TEE type your hardware supports:
 
@@ -378,7 +259,7 @@ helm upgrade akash-provider akash/provider \
 
 ---
 
-## STEP 7 — Verify Setup
+## STEP 6 — Verify Setup
 
 ### Test with a Confidential Deployment
 

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -213,38 +213,49 @@ provider-services run \
 
 ## STEP 5 — Configure Provider Attributes
 
-Tenants discover TEE-capable providers through on-chain attributes. Add the `tee/type` attribute to your `provider.yaml` so your provider appears in TEE-filtered searches. Set the value to the most capable TEE type your hardware supports:
+Tenants discover TEE-capable providers through on-chain attributes. Add both `tee/platform` and `tee/type` to your `provider.yaml`:
 
-### AMD SEV-SNP (CPU only)
+- **`tee/platform`** — the hardware TEE platform: `snp` (AMD SEV-SNP) or `tdx` (Intel TDX)
+- **`tee/type`** — the capability offered: `cpu` (CPU-only) or `cpu-gpu` (CPU + GPU Confidential Computing)
+
+### AMD SEV-SNP, CPU only
 
 ```yaml
 attributes:
+  - key: tee/platform
+    value: snp
   - key: tee/type
-    value: sev-snp
+    value: cpu
 ```
 
-### AMD SEV-SNP + GPU
+### AMD SEV-SNP with GPU
 
 ```yaml
 attributes:
+  - key: tee/platform
+    value: snp
   - key: tee/type
-    value: sev-snp-gpu
+    value: cpu-gpu
 ```
 
-### Intel TDX (CPU only)
+### Intel TDX, CPU only
 
 ```yaml
 attributes:
-  - key: tee/type
+  - key: tee/platform
     value: tdx
+  - key: tee/type
+    value: cpu
 ```
 
-### Intel TDX + GPU
+### Intel TDX with GPU
 
 ```yaml
 attributes:
+  - key: tee/platform
+    value: tdx
   - key: tee/type
-    value: tdx-gpu
+    value: cpu-gpu
 ```
 
 After updating attributes, restart your provider:

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -170,6 +170,34 @@ The operator deploys several components:
 - **nvidia-sandbox-validator** — node-level CC readiness validation
 - **NFD components** — detects CPU TEE capabilities and GPU presence via node labels
 
+## STEP 3b — Label Nodes for TEE Platform Detection
+
+The Akash provider detects the TEE platform at startup by scanning Kubernetes node labels. Standard NFD (Node Feature Discovery) labels like `feature.node.kubernetes.io/cpu-security.sev.snp.enabled` are **not** sufficient. The provider looks for platform-specific labels in a dedicated namespace.
+
+Apply the appropriate label to every TEE-capable node:
+
+### AMD SEV-SNP
+
+```bash
+kubectl label node <node-name> amd.feature.node.kubernetes.io/snp=true
+```
+
+### Intel TDX
+
+```bash
+kubectl label node <node-name> intel.feature.node.kubernetes.io/tdx=true
+```
+
+> **Why not use standard NFD labels?** The provider needs a single, unambiguous signal per platform. NFD exposes many granular CPU feature labels (`SEV`, `SEV_ES`, `SEV_SNP`, `SME`, etc.) but none in the format the provider expects. These dedicated labels act as a provider-level opt-in that confirms the node is fully configured for CC workloads, not just that the CPU has the capability.
+
+Verify the labels were applied:
+
+```bash
+kubectl get nodes --show-labels | grep -E "amd.feature|intel.feature"
+```
+
+---
+
 ## STEP 4 — Configure Provider Flags
 
 The Akash provider automatically injects an attestation sidecar into every confidential workload if requested by the user. This sidecar runs inside the TEE and serves hardware-signed attestation reports to tenants. Enable it with the following flags.
@@ -348,6 +376,16 @@ A successful response contains a hardware-signed attestation report, confirming 
 
 ## Troubleshooting
 
+### Provider not bidding on CC workloads
+
+The provider won't bid on TEE deployments if it can't detect the TEE platform at startup. Check the provider logs for `detected TEE platform`:
+
+```bash
+kubectl logs akash-provider-0 -n akash-services | grep -i "tee platform"
+```
+
+If you see no output or `TEEPlatformNone`, the node labels are missing. Apply them per [Step 3b](#step-3b--label-nodes-for-tee-platform-detection) and restart the provider pod.
+
 ### Pod stuck in Pending
 
 ```bash
@@ -358,6 +396,7 @@ Common causes:
 - **RuntimeClass not found**: Verify the RuntimeClass exists with `kubectl get runtimeclass`
 - **No TEE-capable nodes**: Ensure nodes with TEE hardware are labeled and schedulable
 - **Kata not installed**: Check that Kata is properly installed on the target node
+- **`Insufficient nvidia.com/gpu`**: The provider set `nvidia.com/gpu` instead of `nvidia.com/pgpu`. This means TEE platform detection failed, see the section above
 
 ### Attestation sidecar not injected
 

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -504,7 +504,8 @@ Common causes:
 
 ## Related Topics
 
-- [Confidential Compute Overview](/docs/learn/core-concepts/confidential-compute) - Tenant-facing guide for deploying confidential workloads
-- [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support) - Enable GPU resources on your provider
-- [Provider Attributes](/docs/providers/operations/provider-attributes) - Advertise provider capabilities
+- [Confidential Compute Overview](/docs/learn/core-concepts/confidential-compute) — Tenant-facing guide for deploying confidential workloads
+- [SDL Advanced Features](/docs/developers/deployment/akash-sdl/advanced-features) — SDL reference for TEE configuration
+- [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support) — Enable GPU resources on your provider
+- [Provider Attributes](/docs/providers/operations/provider-attributes) — Advertise provider capabilities
 - [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation) - Base provider setup

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -326,6 +326,36 @@ html body[data-scroll-locked] {
   word-break: break-word;
 }
 
+.prose table {
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.prose td:first-child,
+.prose th:first-child {
+  white-space: nowrap;
+  word-break: normal;
+}
+
+.prose td:last-child,
+.prose th:last-child {
+  white-space: nowrap;
+  word-break: normal;
+}
+
+.prose td:first-child code,
+.prose th:first-child code {
+  white-space: nowrap;
+  word-break: normal;
+}
+
+.prose td:last-child code,
+.prose th:last-child code {
+  white-space: nowrap;
+  word-break: normal;
+}
+
 /* Inline `code` in docs: match body line height; fenced `pre > code` resets below. */
 .prose p code,
 .prose li code,


### PR DESCRIPTION
ref akash-network/support#618

**While running locally**, the following pages were added/updated:

* http://localhost:4321/docs/providers/setup-and-installation/kubespray/confidential-compute/
* http://localhost:4321/docs/learn/core-concepts/confidential-compute/
* http://localhost:4321/docs/providers/operations/provider-attributes/