### PR TITLE
docs: fix broken section anchors in SDL syntax reference

### DIFF
--- a/src/content/Docs/developers/deployment/akash-sdl/syntax-reference/index.mdx
+++ b/src/content/Docs/developers/deployment/akash-sdl/syntax-reference/index.mdx
@@ -463,10 +463,10 @@ deployment:
 ```
 
 **Common patterns:**
-- [GPU deployments](#gpu-section)
-- [Persistent storage](#storage-section)
-- [Private registries](#credentials-section)
-- [Static IPs](#endpoints-section)
+- [GPU deployments](#gpu)
+- [Persistent storage](#storage)
+- [Private registries](#credentials)
+- [Static IPs](#endpoints)
 
 **Resource Limits (per service):**
 


### PR DESCRIPTION
## Summary
Fix four broken in-page anchors in the SDL **Syntax Reference**. The "Common patterns" quick-links pointed to `#gpu-section`, `#storage-section`, `#credentials-section`, and `#endpoints-section`, but the actual section headings slug to `#gpu`, `#storage`, `#credentials`, and `#endpoints` — so every one of these links was a dead jump.

## Changes
| Link text | Before | After |
|---|---|---|
| GPU deployments | `#gpu-section` | `#gpu` |
| Persistent storage | `#storage-section` | `#storage` |
| Private registries | `#credentials-section` | `#credentials` |
| Static IPs | `#endpoints-section` | `#endpoints` |

## Verification
- Confirmed each target heading exists and its slug is unique in the file (headings: `gpu` L337, `storage` L315, `credentials` L217, `Endpoints` L405).
- No prose/content changes — anchors only.
