### PR TITLE
docs: fix grammar in manifest service overview link

### DIFF
--- a/src/content/Docs/providers/architecture/manifest-service/overview.md
+++ b/src/content/Docs/providers/architecture/manifest-service/overview.md
@@ -11,4 +11,4 @@ description: >-
 - [Manifest Initiates an Event Bus to Monitor Lease Won Events](/docs/providers/architecture/manifest-service/#1-lease-won-event)
 - [Monitor Service Loop is Created to React to New Lease Won Events](/docs/providers/architecture/manifest-service/#2-watchdog-creation)
 - [Manifest Manager Logic](/docs/providers/architecture/manifest-service/#5-manifest-processing)
-- [Receipt of Manifest from Tenant Send to Provider](/docs/providers/architecture/manifest-service/#3-manifest-submission)
+- [Receipt of Manifest from Tenant Sent to Provider](/docs/providers/architecture/manifest-service/#3-manifest-submission)


### PR DESCRIPTION
## Summary
Fix 1 high-confidence documentation issue(s) in `providers/architecture/manifest-service/overview.md`.

## Changes

- **typo** — `[Receipt of Manifest from Tenant Send to Provider]` → `[Receipt of Manifest from Tenant Sent to Provider]`

## Verification
- Verified against the live source / target file / CommonMark; anchors checked against both heading slugs and explicit `id=` attributes.
- No unrelated changes.