### PR TITLE
docs: fix broken provider-installation anchors in provider audit

### DIFF
--- a/src/content/Docs/providers/operations/provider-audit/index.md
+++ b/src/content/Docs/providers/operations/provider-audit/index.md
@@ -23,8 +23,8 @@ The **provider audit** is the only path to an official audited badge on Akash. R
 Reference guides:
 
 - [Provider Attributes](/docs/providers/operations/provider-attributes) — how to set each key
-- [Provider Installation — Configure DNS](/docs/providers/setup-and-installation/kubespray/provider-installation/#step-7---configure-dns)
-- [Provider Installation — Verify firewall](/docs/providers/setup-and-installation/kubespray/provider-installation/#step-12---verify-firewall)
+- [Provider Installation — Configure DNS](/docs/providers/setup-and-installation/kubespray/provider-installation-prep#step-7---configure-dns)
+- [Provider Installation — Verify firewall](/docs/providers/setup-and-installation/kubespray/provider-installation/#step-6---verify-firewall)
 
 ---
 


### PR DESCRIPTION
## Summary
Fix 2 high-confidence documentation issue(s) in `providers/operations/provider-audit/index.md`.

## Changes

- **broken-internal-link** — `[Provider Installation — Verify firewall](/docs/providers/se…` → `[Provider Installation — Verify firewall](/docs/providers/se…`
- **broken-internal-link** — `[Provider Installation — Configure DNS](/docs/providers/setu…` → `[Provider Installation — Configure DNS](/docs/providers/setu…`

## Verification
- Verified against the live source / target file / CommonMark; anchors checked against both heading slugs and explicit `id=` attributes.
- No unrelated changes.