### PR TITLE
docs: fix non-existent NVIDIA CUDA image tag in GPU smoke test

### DIFF
--- a/src/content/Docs/providers/setup-and-installation/kubespray/gpu-support/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/gpu-support/index.md
@@ -258,7 +258,7 @@ Done
 Create an interactive test:
 
 ```bash
-kubectl run gpu-shell --rm -it --restart=Never --image=nvidia/cuda:11.6.0-base-ubuntu20.04 -- nvidia-smi
+kubectl run gpu-shell --rm -it --restart=Never --image=nvidia/cuda:11.6.2-base-ubuntu20.04 -- nvidia-smi
 ```
 
 You should see GPU information displayed.


### PR DESCRIPTION
## Summary
Fix 1 high-confidence documentation issue(s) in `providers/setup-and-installation/kubespray/gpu-support/index.md`.

## Changes

- **wrong-command** — `--image=nvidia/cuda:11.6.0-base-ubuntu20.04` → `--image=nvidia/cuda:11.6.2-base-ubuntu20.04`

## Verification
- Verified against the live source / target file / CommonMark; anchors checked against both heading slugs and explicit `id=` attributes.
- No unrelated changes.