### PR TITLE
docs: fix nested code fence and stale anchor in documentation guide

### DIFF
--- a/src/content/Docs/developers/contributing/documentation-guide/index.md
+++ b/src/content/Docs/developers/contributing/documentation-guide/index.md
@@ -141,7 +141,7 @@ Common issues and solutions
 Links to related guides
 ```
 
-**Example:** [Update a Deployment](/docs/developers/deployment/cli/common-tasks#update-a-deployment)
+**Example:** [Update a Deployment](/docs/developers/deployment/cli/common-tasks#update-deployment-2-step-process)
 
 ### 3. Reference Documentation
 
@@ -556,7 +556,7 @@ Before you begin, ensure you have:
 
 **Solution:**
 Always include working examples:
-```markdown
+````markdown
 ## Theory
 Deployments are created from SDL files...
 
@@ -571,7 +571,7 @@ Use it like this:
 ```bash
 provider-services tx deployment create deploy.yaml
 ```
-```
+````
 
 ---
 


### PR DESCRIPTION
## Summary
Fix 2 high-confidence documentation issue(s) in `developers/contributing/documentation-guide/index.md`.

## Changes

- **broken-rendering** — ````markdown\n## Theory\nDeployments are created from SDL fil…` → `````markdown\n## Theory\nDeployments are created from SDL fi…`
- **broken-internal-link** — `[Update a Deployment](/docs/developers/deployment/cli/common…` → `[Update a Deployment](/docs/developers/deployment/cli/common…`

## Verification
- Verified against the live source / target file / CommonMark; anchors checked against both heading slugs and explicit `id=` attributes.
- No unrelated changes.