### PR TITLE
docs: fix directional reference in IP leases migration note

### DIFF
--- a/src/content/Docs/learn/core-concepts/ip-leases/index.md
+++ b/src/content/Docs/learn/core-concepts/ip-leases/index.md
@@ -399,7 +399,7 @@ Access your services:
 ### Per-Deployment
 
 IP leases are **per-deployment**, not per-account:
-- IP leases can be migrated between deployments on the same provider (see IP Lease Migration above)
+- IP leases can be migrated between deployments on the same provider (see IP Lease Migration below)
 - Closing a deployment without migration releases the IP
 - Switching providers = new IP (cannot migrate across providers)
 


### PR DESCRIPTION
## Summary
Fix 1 high-confidence documentation issue(s) in `learn/core-concepts/ip-leases/index.md`.

## Changes

- **typo** — `IP leases can be migrated between deployments on the same pr…` → `IP leases can be migrated between deployments on the same pr…`

## Verification
- Verified against the live source / target file / CommonMark; anchors checked against both heading slugs and explicit `id=` attributes.
- No unrelated changes.