### PR TITLE
docs: fix mislabeled Ping.pub explorer link

### DIFF
--- a/src/content/Docs/node-operators/validators/tmkms-stunnel/index.md
+++ b/src/content/Docs/node-operators/validators/tmkms-stunnel/index.md
@@ -690,7 +690,7 @@ akash query staking validator $(akash keys show $AKASH_KEYNAME --bech val -a)
 
 Check on [Akash Block Explorers](/docs/node-operators/validators/):
 - [Mintscan](https://www.mintscan.io/akash/validators)
-- [Ping.pub](https://www.mintscan.io/akash/validators)
+- [Ping.pub](https://ping.pub/akash/staking)
 
 ---
 


### PR DESCRIPTION
## Summary
Fix a mislabeled explorer link in the TMKMS validator guide. The "Ping.pub" list item pointed to `mintscan.io` (a duplicate of the Mintscan line directly above it); restored the correct Ping.pub URL.

```diff
- [Ping.pub](https://www.mintscan.io/akash/validators)
+ [Ping.pub](https://ping.pub/akash/staking)
```

Verified `https://ping.pub/akash/staking` loads the Akash validators page (the link is live — it's a client-rendered SPA, which is why an automated HEAD check had wrongly flagged it).
