### PR TITLE
Hide $100 GPU credits badge on homepage hero

### DIFF
--- a/src/components/home/hero/hero.astro
+++ b/src/components/home/hero/hero.astro
@@ -42,11 +42,13 @@ const pathname = Astro.url.pathname;
       <div class="flex justify-center" style="min-height:48px;">
         <TryAkashForm client:load type="hero" />
       </div>
+      {/* Hidden for now
       <div
         class="mx-auto flex items-center gap-2 rounded-full border bg-background2 px-4 py-2 text-center text-xs dark:bg-[#242429]/45"
       >
         <p class="text-[12.4px] text-[#8C8E91]">Get up to $100 in GPU credits</p>
       </div>
+      */}
     </div>
 
   </div>


### PR DESCRIPTION
## What

Temporarily hides the "Get up to \$100 in GPU credits" badge that appears below the Deploy Now button in the homepage hero.

## Why

Hiding it for now (per request).

## How

Commented out the badge `<div>` in [hero.astro](src/components/home/hero/hero.astro#L45) using an Astro `{/* */}` comment so it's removed from the rendered output but easy to restore later.

## Screenshot reference

The badge being hidden is the pill reading "Get up to \$100 in GPU credits" directly under the **Deploy Now** CTA.