### PR TITLE
docs: update Console getting-started docs for new onboarding flow

### DIFF
--- a/src/content/Docs/developers/deployment/akash-console/getting-started/index.md
+++ b/src/content/Docs/developers/deployment/akash-console/getting-started/index.md
@@ -28,41 +28,75 @@ Akash Console is a web-based deployment platform that provides:
 
 ## Getting Started
 
-### Step 1: Access Akash Console
+### Step 1: Sign Up
 
-Visit [console.akash.network](https://console.akash.network) in your web browser.
+Visit [console.akash.network](https://console.akash.network) and click **"Start deploying"**.
 
-![Console Homepage](/images/docs/console/1-console-homepage.png)
-*Akash Console homepage - Start with the free trial in a few clicks*
+Choose how you want to sign up:
 
-### Step 2: Sign Up for Free Trial
+- **Continue with Google**
+- **Continue with GitHub**
+- **Continue with email** — we'll email you a 6-digit code, so there's no password to remember
 
-1. Click **"Start Free Trial"** or **"Get Started"**
-2. Enter your email address
-3. Add a credit card (for verification and pay-as-you-go after trial)
-4. Receive **$100 in free trial credits**
+**No credit card required.** You get **$1 in free trial credits** to deploy your first container right away.
 
-![Trial Signup](/images/docs/console/2-trial-signup.png)
-*Sign up with email and credit card to receive $100 in trial credits*
+<!-- SCREENSHOT: The "Start deploying" sign-up screen showing Google / GitHub / email options and the "$1 credit to deploy your first container. No card required." copy -->
+![Sign up for Akash Console](/images/docs/console/onboarding-1-signup.png)
+*Sign up with Google, GitHub, or a passwordless email code—no credit card required*
 
-**Free trial limits:**
+### Step 2: Choose How to Get Started
 
-- **24-hour deployments** — trial deployments auto-close after 24 hours.
-- **No high-end GPUs** — H100, H200, A100, RTX 4090, and RTX 5090 are not available on the free trial.
+After signing up, Console opens straight into **"Let's deploy your first app."** The rest of the app stays gated until your first deployment is live, so you can focus on getting something running.
 
-Add a payment method to switch to pay-as-you-go for longer deployments and access to all GPU types on the network.
+You have two paths:
 
-### Step 3: Explore Your Dashboard
+- **Pick a ready-to-go template** — a curated set of one-click apps (web apps, AI models, databases, and more) that get you a live URL in about 30 seconds.
+- **Deploy your own image** — bring your own Docker image or custom SDL. See [Deploy your own app](#deploy-your-own-app) below.
 
-After signing up, you'll see your Console dashboard with:
+You start with **$1 in free trial credits**, and on your first purchase you also get **10% in bonus credits, up to $100**. Some templates (such as high-end GPU apps) require adding a card to unlock.
 
-- **Trial Status** - $100.00 in credits with 30 days remaining
-- **Setup Progress** - Track completion of onboarding steps
-- **Featured Templates** - Quick-deploy options like Hello Akash, ComfyUI, and Llama-3.1-8b
-- **One-Click Deploy** - Launch your first app in seconds
+<!-- SCREENSHOT: The "Let's deploy your first app" path picker showing the template cards and the "$1 in free trial credits… 10% in bonus credits… up to $100" sub-heading -->
+![Choose a template or deploy your own image](/images/docs/console/onboarding-2-path-picker.png)
+*"Let's deploy your first app"—pick a template or deploy your own image*
 
-![Trial Dashboard](/images/docs/console/3-trial-dashboard.png)
-*Console dashboard showing trial credits, setup progress, and featured templates ready to deploy*
+### Step 3: Watch Your First Deployment Go Live
+
+Pick a template and Console handles the rest for you—no deposit to set, no provider bids to compare. You'll see the deploy funnel move through:
+
+1. **Creating deployment**
+2. **Matching with providers** — Console automatically picks the best host for you
+3. **Preparing deployment**
+
+Typical deploys take **15–30 seconds**. When your deployment is ready, Console automatically redirects you to it with a live URL.
+
+<!-- SCREENSHOT: The provisioning funnel ("Deploying {template}", "We'll pick the best host for you…", phase progress Creating → Matching → Preparing) -->
+![Your first deployment provisioning](/images/docs/console/onboarding-3-deploying.png)
+*Console creates the deployment, matches a provider, and redirects you when it's ready*
+
+### Free Trial Limits
+
+Your free trial gives you room to explore:
+
+- **$1 in free trial credits** to deploy your first apps
+- **30-day trial window**
+- **24-hour deployments** — trial deployments last a maximum of 1 day, but you can redeploy as many times as you like during the trial
+- **No high-end GPUs** — high-end GPUs (such as the NVIDIA H100, H200, B200, A100, and RTX 5090/4090) aren't included in the free trial
+
+To run longer deployments and unlock high-end GPUs, add credits to move to pay-as-you-go (see below).
+
+### Skip the Trial
+
+Ready to go beyond the trial? Add credits at any time to unlock the full Console and switch to pay-as-you-go:
+
+1. Choose **"Skip the trial - unlock Console"** (or **"Add funds"** once you're in the app)
+2. Add credits with a card — the minimum top-up is **$20**
+3. That's it — longer runtimes, high-end GPUs, and the full Console are unlocked
+
+**First-purchase bonus:** On your first purchase of $100 or more, get 10% in bonus credits, up to $100.
+
+<!-- SCREENSHOT: The Add Credits sheet showing the credit amount, the $20 minimum, and the 10% first-purchase bonus -->
+![Add credits to unlock Console](/images/docs/console/onboarding-4-skip-trial-credits.png)
+*Add credits to unlock pay-as-you-go—your first purchase earns a 10% bonus*
 
 ---
 
@@ -78,12 +112,13 @@ Build your deployment configuration visually without writing YAML:
 - **Environment Variables** - Add environment variables to your containers
 - **Pricing** - Set maximum bid prices
 
+<!-- VERIFY: SDL Builder form UI still matches this screenshot -->
 ![SDL Builder Interface](/images/docs/console/4-sdl-builder-interface.png)
 *Visual SDL Builder - configure your deployment using a form-based interface*
 
 ### Pre-Built Templates
 
-Browse 290+ ready-to-deploy application templates:
+Browse ready-to-deploy application templates:
 
 - **AI/ML Models** - Stable Diffusion, LLMs, Ollama, Open WebUI
 - **Databases** - PostgreSQL, MongoDB, Redis, MySQL
@@ -91,9 +126,11 @@ Browse 290+ ready-to-deploy application templates:
 - **Development Tools** - Jupyter, VS Code Server
 - **And much more...**
 
+<!-- VERIFY: Templates library grid still matches this screenshot -->
 ![Templates Library](/images/docs/console/5-templates-library.png)
 *Browse pre-built templates for common applications*
 
+<!-- VERIFY: Template detail page still matches this screenshot -->
 ![Template Detail](/images/docs/console/6-template-detail.png)
 *View template details and deploy with one click*
 
@@ -101,62 +138,66 @@ Browse 290+ ready-to-deploy application templates:
 
 Monitor and manage all your deployments:
 
-- **Active Deployments** - See all running deployments
+- **Active Leases** - See all running deployments
 - **Deployment Status** - Real-time status updates
 - **Logs** - View container logs directly in the console
-- **Events** - Monitor deployment events and shell access
+- **Events** - Monitor deployment events
+- **Shell** - Open a shell into your running container
 - **URLs** - Access your deployed applications
 
+<!-- VERIFY: Deployments/Leases dashboard still matches this screenshot (now a "Leases" tab; Balance/Cost/Spent labels) -->
 ![Deployments Dashboard](/images/docs/console/15-deployments-dashboard.png)
 *Manage all your deployments from a single dashboard*
 
 ---
 
-## Quick Example: Deploy a Web App
+## Deploy Your Own App
+
+The guided flow above picks a provider for you automatically. When you bring your own Docker image or custom SDL, you get the full configure screen—including choosing your own provider.
 
 ### Step-by-Step Deployment Flow
 
 #### 1. Configure Your Deployment
 
-Use the SDL Builder or choose a template, then customize your configuration:
+Use the SDL Builder or start from a template, then customize your image, resources, and settings:
 
+<!-- VERIFY: SDL configuration screen still matches this screenshot -->
 ![SDL Configuration](/images/docs/console/7-sdl-configuration.png)
 *Configure your deployment with SDL or use the visual builder*
 
-#### 2. Set Deposit Amount
+#### 2. Review and Deploy
 
-Set the initial deposit for your deployment:
+Review your configuration and deploy. A small deployment deposit is set aside automatically from your credit balance and returned when you close the deployment—there's no deposit amount to enter and no crypto involved.
 
+<!-- SCREENSHOT: Deployment review screen for a custom/BYO deploy (USD credits, automatic deposit—no ACT, no manual deposit field) -->
 ![Deployment Review](/images/docs/console/8-deployment-review.png)
-*Set your deposit amount - this is held in escrow (ACT) and refunded when you close the deployment*
+*Review your deployment—the deposit is handled automatically in USD credits*
 
-The deposit (in **ACT**):
-- Is held in escrow to pay for your deployment; create deployments with ACT only (or AKT when circuit breaker is in effect)
-- Gets refunded when you close the deployment
-- You can top up with ACT (or AKT when circuit breaker is active) if running low
+#### 3. Choose Your Provider
 
-#### 3. Select a Provider Bid
+For a bring-your-own-image deploy, Console lets you pick the provider yourself. Once providers respond, compare them and choose one based on:
 
-After creating the deployment, providers will submit bids. Choose one based on:
 - **Price** - Cost per month
 - **Location** - Geographic region
 - **Attributes** - Features and certifications
 
-![Bid Selection](/images/docs/console/10-bid-selection.png)
-*Review and accept provider bids for your deployment*
+<!-- SCREENSHOT: Provider selection screen for the manual/BYO path (guided template deploys match automatically; this documents "Choose my provider") -->
+![Provider Selection](/images/docs/console/10-bid-selection.png)
+*Compare providers and pick one for your bring-your-own-image deployment*
 
 #### 4. Access Your Running Deployment
 
-Once the bid is accepted, your deployment will start running:
+Once the provider is selected, your deployment starts running:
 
+<!-- SCREENSHOT: Active deployment/lease detail view (live URLs, Cost/Spent labels in USD) -->
 ![Deployment Active](/images/docs/console/12-deployment-active.png)
 *Your deployment is live with URLs and status information*
 
 You'll see:
 - **Live URLs** - Access your application
--  **Status** - Real-time deployment state
--  **Cost Tracking** - Current spending
--  **Management Controls** - Update, logs, close
+- **Status** - Real-time deployment state
+- **Cost Tracking** - Current spending
+- **Management Controls** - Update, logs, close
 
 ---
 
@@ -170,7 +211,7 @@ You'll see:
 - Want quick deployments with pre-built templates
 - Need to manage multiple deployments with a dashboard view
 - Want to try Akash with free trial credits
-- Prefer browsing provider bids visually
+- Prefer pay-as-you-go billing with a credit card
 
 ### When to Use CLI
 
@@ -192,31 +233,34 @@ You'll see:
 
 Monitor your application's output in real-time:
 
-1. Go to **"Deployments"** in the sidebar
+1. Go to **"Leases"** in the sidebar
 2. Click on your deployment
-3. Navigate to **"Logs"** tab
+3. Navigate to the **"Logs"** tab
 4. View real-time container logs
 
+<!-- VERIFY: Logs tab still matches this screenshot -->
 ![Deployment Logs](/images/docs/console/13-deployment-logs.png)
 *View real-time logs from your running containers*
 
-### Monitor Events and Shell Access
+### Monitor Events and Open a Shell
 
-Access deployment events and shell terminal:
+Deployment **Events** and **Shell** are now separate tabs. Use **Events** to follow lifecycle activity and **Shell** to open a terminal into your running container:
 
+<!-- VERIFY: Events tab still matches this screenshot (Shell is now its own tab) -->
 ![Deployment Events](/images/docs/console/14-deployment-events.png)
-*View deployment events and access shell terminal*
+*View deployment events; open a terminal from the Shell tab*
 
 ### Update a Deployment
 
 Modify your running deployment without downtime:
 
 1. Select your deployment
-2. Click **"Edit"** or **"Update"**
+2. Click **"Update"**
 3. Modify your SDL or configuration
 4. Click **"Update Deployment"**
 5. Changes will be applied to your running deployment
 
+<!-- VERIFY: Update deployment screen still matches this screenshot -->
 ![Deployment Update](/images/docs/console/16-deployment-update.png)
 *Update your deployment configuration on the fly*
 
@@ -224,31 +268,36 @@ Modify your running deployment without downtime:
 
 ### Close a Deployment
 
-Stop your deployment and reclaim your deposit:
+Stop your deployment and return the deposit to your balance:
 
 1. Select your deployment
-2. Click **"Close"** or **"Stop"**
+2. Click **"Close"**
 3. Confirm the action
-4. Your deployment will stop and remaining escrow (ACT) will be refunded
+4. Your deployment stops and the automatic deposit is returned to your credit balance
 
+<!-- VERIFY: Close deployment confirmation still matches this screenshot -->
 ![Deployment Close Confirmation](/images/docs/console/17-deployment-close.png)
-*Confirm deployment closure and reclaim your deposit*
+*Confirm deployment closure—the deposit returns to your balance*
 
+<!-- VERIFY: Deployment-closed confirmation still matches this screenshot -->
 ![Deployment Closed](/images/docs/console/17.1-deployment-close.png)
 *Deployment successfully closed*
 
 ### Manage Billing and Credits
 
-View your trial credits and add payment methods (credits are in **ACT**):
+View your credit balance and add funds (everything is in USD credits):
 
+<!-- SCREENSHOT: Billing/Credits screen showing USD balance and the 10% first-purchase bonus -->
 ![Billing and Credits](/images/docs/console/18-billing-credits.png)
-*Manage your trial credits, payment methods, and billing*
+*Manage your credits, payment methods, and billing*
 
 You can:
-- Check remaining trial credits (ACT)
-- Add or update credit card (funds ACT)
+- Check your remaining credits
+- Add credits or update your card (minimum top-up $20)
+- Turn on auto top-up so you never run out
 - View spending history
-- Convert to pay-as-you-go after trial expires
+
+**First-purchase bonus:** On your first purchase of $100 or more, get 10% in bonus credits, up to $100.
 
 ---
 
@@ -256,7 +305,7 @@ You can:
 
 - **[Console Air](https://github.com/akash-network/console-air)** - Self-custody alternative — bring your own Keplr wallet and run the UI yourself
 - **[Console API](/docs/api-documentation/console-api)** - Programmatic deployments with REST API
-- **[SDL Examples Library](/docs/developers/deployment/akash-sdl/examples-library)** - 290+ deployment examples for all application types
+- **[SDL Examples Library](/docs/developers/deployment/akash-sdl/examples-library)** - Deployment examples for all application types
 - **[SDL Reference](/docs/developers/deployment/akash-sdl)** - Deep dive into Stack Definition Language
 - **[CLI Documentation](/docs/developers/deployment/cli)** - Learn command-line deployment
 
@@ -271,4 +320,3 @@ You can:
 ---
 
 **Ready to deploy?** Visit [console.akash.network](https://console.akash.network) and create your first deployment!
-

--- a/src/content/Docs/developers/deployment/akash-console/index.md
+++ b/src/content/Docs/developers/deployment/akash-console/index.md
@@ -51,7 +51,7 @@ Programmatic deployments using the Console API:
 ## Quick Links
 
 **New to Akash?**  
-→ [Free Trial Quick Start](/docs/getting-started/quick-start) - Deploy in 10 minutes with $100 free credits
+→ [Free Trial Quick Start](/docs/getting-started/quick-start) - Deploy in 10 minutes with $1 in free trial credits
 
 **Need Examples?**  
 → [SDL Examples Library](/docs/developers/deployment/akash-sdl/examples-library) - 290+ deployment templates

--- a/src/content/Docs/developers/deployment/index.md
+++ b/src/content/Docs/developers/deployment/index.md
@@ -16,7 +16,7 @@ This section covers everything you need to deploy applications, including Akash 
 ## Deployment Methods
 
 ### [Akash Console](/docs/developers/deployment/akash-console)
-**Visual web interface (managed)** - Deploy using the browser-based Console with free trial OR your own wallet. No CLI required.
+**Visual web interface (managed)** - Deploy using the browser-based Console with a free trial or pay-as-you-go credit-card billing. No CLI required.
 
 ### [Console Air](/docs/developers/deployment/console-air)
 **Visual web interface (self-custody)** - Self-hostable counterpart to Akash Console. Connect your own Keplr wallet and sign every transaction yourself — no managed billing, no time limits.

--- a/src/content/Docs/getting-started/choosing-your-console/index.md
+++ b/src/content/Docs/getting-started/choosing-your-console/index.md
@@ -21,7 +21,7 @@ description: "Akash ships two web apps for deploying — Console (managed) and C
 
 **Do you want to hold your own keys?**
 
-- **No** → [Akash Console](https://console.akash.network). Sign up with email, add a credit card, start deploying. Begin with the [Quick Start](/docs/getting-started/quick-start).
+- **No** → [Akash Console](https://console.akash.network). Sign up with Google, GitHub, or a passwordless email code—no credit card required to start deploying. Begin with the [Quick Start](/docs/getting-started/quick-start).
 - **Yes** → [Console Air](https://github.com/akash-network/console-air). Clone the repo, run it locally, connect your wallet. New here? Walk through your first deploy in [Deploy with Console Air](/docs/developers/deployment/console-air). Already have deployments on `console.akash.network`? Follow the [migration guide](https://github.com/akash-network/console-air/blob/main/docs/migrating-from-akash-console.md).
 
 For programmatic access — CLI, SDK, REST API — see the [API Documentation](/docs/api-documentation/getting-started).

--- a/src/content/Docs/getting-started/core-concepts/index.md
+++ b/src/content/Docs/getting-started/core-concepts/index.md
@@ -65,7 +65,7 @@ Your escrow pays the provider per block (~6 seconds) in **ACT**.
 
 ### Akash Console (Easiest)
 - Visual web interface
-- $100 free trial (no wallet needed)
+- $1 free trial (no wallet or card needed)
 - Perfect for beginners
 
 ### CLI (Most Control)

--- a/src/content/Docs/getting-started/index.md
+++ b/src/content/Docs/getting-started/index.md
@@ -3,10 +3,10 @@ categories: ["Getting Started"]
 tags: ["Getting Started", "Onboarding", "Tutorial", "Console", "Free Trial"]
 title: "Getting Started"
 linkTitle: "Getting Started"
-description: "Get started with Akash Network - deploy your first application in minutes with $100 free credits"
+description: "Get started with Akash Network - deploy your first application in minutes with $1 in free trial credits"
 ---
 
-**Welcome to Akash Network! Start deploying in minutes with $100 in free credits—no crypto wallet required.**
+**Welcome to Akash Network! Start deploying in minutes with $1 in free trial credits—no crypto wallet or credit card required.**
 
 Akash Console is a web-based platform that makes deploying on Akash Network as easy as using AWS or GCP—no command line or blockchain experience needed!
 
@@ -14,12 +14,12 @@ Akash Console is a web-based platform that makes deploying on Akash Network as e
 
 ## Start Your Free Trial
 
-**Get $100 in free credits** to deploy applications on Akash Network:
+**Get $1 in free trial credits** to deploy applications on Akash Network:
 
-- **$100 free credits** - No charge during trial
+- **$1 free trial credits** - Deploy your first container, no charge
 - **30 days** - Plenty of time to explore
-- **Credit card required** - For identity verification only (prevents abuse)
-- **No automatic charges** - You're in control
+- **No credit card required to start** - Add a card only when you want to add credits
+- **10% first-purchase bonus** - On your first purchase of $100 or more, get 10% in bonus credits (up to $100)
 
 ### [Quick Start - Free Trial](/docs/getting-started/quick-start)
 **Deploy your first application in under 10 minutes** using the web interface—perfect for beginners!
@@ -46,7 +46,7 @@ Learn about deployments, providers, and how Akash works.
 
 **The easiest way to get started with decentralized cloud:**
 
-- **Free Trial** - $100 in credits, no crypto required
+- **Free Trial** - $1 in credits, no crypto or credit card required
 - **One-Click Templates** - Deploy popular apps instantly
 - **No CLI Required** - Everything in your browser
 - **Visual Interface** - Build and manage deployments visually

--- a/src/content/Docs/getting-started/quick-start/index.md
+++ b/src/content/Docs/getting-started/quick-start/index.md
@@ -4,7 +4,7 @@ tags: ["Quick Start", "Console", "Tutorial", "Beginner", "Free Trial"]
 weight: 4
 title: "Quick Start - Deploy with Free Trial"
 linkTitle: "Quick Start"
-description: "Deploy your first application on Akash Network in under 10 minutes with $100 in free credits"
+description: "Deploy your first application on Akash Network in under 10 minutes with $1 in free trial credits"
 ---
 
 **Deploy your first application on Akash Network in under 10 minutes—no crypto wallet or blockchain experience required!**
@@ -15,7 +15,7 @@ This guide walks you through signing up for the free trial and deploying your fi
 
 ## What You'll Get
 
-- **$100 in free credits** - No charge during trial
+- **$1 in free trial credits** - Deploy your first container, no card required
 - **30 days** - Plenty of time to explore Akash
 - **One-click deployment** - Use pre-built templates
 - **Live URL** - Access your deployed application instantly
@@ -30,172 +30,91 @@ This guide walks you through signing up for the free trial and deploying your fi
 
 All you need is:
 
-1. **A valid email address** (for account verification)
-2. **A valid credit card** (for identity verification)
-   - Must have at least $1 available
-   - A temporary $1 charge will be placed and immediately refunded
-   - Used to verify identity and prevent spam/abuse
+1. **A valid email address** — or a Google or GitHub account
 
-**Note:** You won't be charged beyond the refundable $1 verification unless you exceed your $100 free credits or choose to add more funds.
-
-That's it! No crypto wallet, no blockchain setup, no installation required.
+That's it! **No credit card, no crypto wallet, no blockchain setup, no installation required.** You add a card later only if you decide to add credits, unlock high-end GPUs, or move to pay-as-you-go.
 
 ---
 
 ## Step 1: Visit Akash Console
 
-Open your browser and go to **[console.akash.network](https://console.akash.network)**
-
-You'll see a banner at the top: **"Credit Card payments are now available!"** (credit card funds **ACT** for deployments.)
+Open your browser and go to **[console.akash.network](https://console.akash.network)** and click **"Start deploying"**.
 
 ---
 
-## Step 2: Start Your Free Trial
+## Step 2: Create Your Account
 
-1. Click the **"Start Trial"** button in the top right corner (it's the bright red/pink button)
+Choose one of three sign-up options. There's no password to create and no credit card to enter.
 
-2. You'll see the trial benefits page showing:
-   - 100$ of free credits
-   - 30 days of free credits
-   - Deployments last up to 24 hours
-   - Keep unused free credits if you purchase credits
-
-3. Click the **"Start Free Trial"** button to continue
-
----
-
-## Step 3: Create Your Account
-
-Choose one of three signup options:
-
-### Option A: Sign up with GitHub (Fastest!)
-1. Click **"Sign up with GitHub"**
+### Option A: Continue with GitHub (Fastest!)
+1. Click **"Continue with GitHub"**
 2. Authorize Akash Console in the popup
 3. Done! Skip to Step 4
 
-### Option B: Sign up with Google (Fastest!)
-1. Click **"Sign up with Google"**
+### Option B: Continue with Google (Fastest!)
+1. Click **"Continue with Google"**
 2. Choose your Google account
 3. Done! Skip to Step 4
 
-### Option C: Sign up with Email
+### Option C: Continue with Email
 1. Enter your email address
-2. Create a strong password
-3. Complete the CAPTCHA
-4. (Optional) Uncheck newsletter if you don't want updates
-5. Check "I have read and agree to Terms of Services"
-6. Click **"SIGN UP"**
+2. Click continue — we'll email you a 6-digit code (no password to remember)
 
 ---
 
-## Step 4: Verify Your Email
+## Step 3: Enter Your Email Code
 
-1. Check your email inbox for a verification message from Akash
-2. Click the verification link in the email
-3. You'll see: **"Email Verified - Your email has been successfully verified"**
-4. Click **"Continue"**
+If you signed up with email:
 
----
-
-## Step 5: Add Payment Method
-
-To prevent abuse, Akash requires a credit card for identity verification. **You won't be charged during the trial.**
-
-1. Fill in the payment form (used to fund **ACT** for deployments):
-   - **Organization** (optional)
-   - **Billing Address** (Full name, Country, Address)
-   - **Card Information** (Card number, Expiration date, CVV)
-
-2. Your card will show up as saved (e.g., "DISCOVER •••• 9564")
-3. Click **"Start Trial"**
-
-**What happens to your card?**
-- **$1 verification charge** - A temporary $1 charge will be placed and immediately refunded (ensure card is valid)
-- Used for identity verification only
-- No other charges during your $100 trial
-- Only charged if you exceed free credits or choose to add more funds
-- Can be removed anytime after verification
+1. Check your inbox for a 6-digit code from Akash
+2. Enter the code in Console
+3. You're in — with **$1 in free trial credits** ready to deploy
 
 ---
 
-## Step 6: Welcome to Akash!
+## Step 4: Choose How to Get Started
 
-You're in! You'll see your dashboard with:
+Console opens straight into **"Let's deploy your first app."** The rest of the app stays gated until your first deployment is live, so you can focus on getting something running.
 
-- **Trial Status Banner** - Shows your $100 credit balance and 30 days remaining
-- **Important:** Deployments last maximum 1 day during trial
-- **Account Overview** - $100.00 remaining of $100.00
+You'll see a set of ready-to-go templates plus an option to deploy your own image. Your trial gives you:
 
----
+- **$1 in free trial credits** to deploy right away
+- **10% in bonus credits on your first purchase, up to $100** (when you're ready to add funds)
 
-## Step 7: Deploy Your First Application
-
-You'll see the welcome screen with **"Choose a template below to launch your first app in seconds."**
-
-**Several featured templates are displayed:**
+Some templates (such as high-end GPU apps) require adding a card to unlock.
 
 ### Option A: Use a Featured Template (Recommended for First Deployment)
 
-Perfect for testing! Choose any featured template to get started.
+Perfect for testing! Pick any template to get a live URL in about 30 seconds.
 
-1. Browse the available templates on the welcome screen
-2. Select a template that interests you (web apps, databases, etc.)
+1. Browse the templates on the welcome screen
+2. Select one that interests you (web apps, databases, AI models, etc.)
 3. Read the template description
-4. Click **"Deploy Now"**
-5. Review the pre-filled configuration
-6. Click **"Create Deployment"**
+4. Click **Deploy**
 
-Wait ~1-2 minutes for deployment to complete
+### Option B: Deploy an AI Model
 
-Your first app is live!
+Want to try something more advanced? Pick an AI/image-generation or language-model template (for example, a Stable Diffusion or Llama template).
 
-### Option B: ComfyUI (AI/Image Generation)
-
-Want to try something more advanced?
-
-1. Find the **"ComfyUI"** card (artist with easel icon)
-2. Read the description: *"A powerful, modular Stable Diffusion tool that lets you build and run advanced image workflows using a visual, node-based interface."*
-3. Click **"Deploy Now"**
-4. Follow the deployment steps
-
-**Note:** This requires more resources and will use more of your trial credits.
-
-### Option C: Llama-3.1-8b (Language Model)
-
-Deploy a cutting-edge AI language model!
-
-1. Find the **"Llama-3.1-8b"** card (basketball player icon)
-2. Read the description: *"A cutting-edge language model built for fast, context-aware text generation. Access a wide range of advanced language tasks."*
-3. Click **"Deploy Now"**
-4. Follow the deployment steps
-
-**Note:** GPU deployments use credits faster but are incredibly powerful!
+**Note:** AI and GPU workloads use more of your trial credits, and high-end GPUs require adding credits to unlock.
 
 ---
 
-## Step 8: Wait for Deployment
+## Step 5: Watch Your Deployment Go Live
 
-After clicking "Deploy Now" on any template:
+After you pick a template, Console handles the rest—no deposit to set and no provider bids to compare. You'll see the deploy funnel move through:
 
-1. Console will show **"Creating Deployment..."**
-2. Providers will automatically bid to host your application
-3. The best bid is automatically selected
-4. Your application starts deploying
+1. **Creating deployment**
+2. **Matching with providers** — Console automatically picks the best host for you
+3. **Preparing deployment**
 
-**Total time:** 1-3 minutes (depending on the template)
-
-You'll see status updates:
-- "Creating Deployment..." 
-- "Accepting Bid..."
-- "Sending Manifest..."
-- "Starting Services..."
-- **"Running"**
+**Total time:** typically 15–30 seconds. When your deployment is ready, Console automatically redirects you to it.
 
 ---
 
-## Step 9: Access Your Deployment
+## Step 6: Access Your Deployment
 
-Once your deployment shows **"Running"** status:
+Once your deployment is live:
 
 1. Look for the **"URIs"** or **"Access URLs"** section in your deployment details
 2. Click on the URL shown (e.g., `https://your-app.provider.akash.network`)
@@ -208,7 +127,7 @@ Once your deployment shows **"Running"** status:
 - **Visit your deployed app** - Click the URL to see it live
 - **View logs** - Check the "Logs" tab to see what's happening
 - **Monitor resources** - See CPU, memory, and storage usage
-- **Check your balance** - Watch how much of your $100 credit you're using
+- **Check your balance** - Watch how much of your credit you're using
 
 ---
 
@@ -225,23 +144,23 @@ In the Console deployment page:
 
 To change your deployment configuration:
 1. Click on your active deployment
-2. Click **"Update Deployment"**
+2. Click **"Update"**
 3. Edit the SDL configuration in the editor
-4. Click **"Update"** to apply changes
+4. Click **"Update Deployment"** to apply changes
 
 **Note:** Updates modify your existing lease and may briefly interrupt service during the container restart.
 
 ### Close Your Deployment
 
-**Important:** Remember trial deployments last maximum 1 day!
+**Important:** Remember trial deployments last a maximum of 1 day!
 
 When you're done testing:
-1. Go to your **"Deployments"** page
+1. Go to your **"Leases"** page
 2. Find your active deployment
-3. Click **"Close Deployment"**
+3. Click **"Close"**
 4. Confirm the closure
 
-**Always close deployments when you're done to conserve your $100 trial credits.**
+Closing a deployment returns its automatic deposit to your credit balance. **Always close deployments when you're done to conserve your trial credits.**
 
 ---
 
@@ -249,10 +168,10 @@ When you're done testing:
 
 The Console dashboard shows:
 
-- **Trial Status** - Your $100 credit balance, days remaining, and usage
-- **Active Deployments** - All your currently running deployments (max 1 day each during trial)
-- **Deployment Costs** - Real-time spending from your trial credits
-- **Account Balance** - Visual chart showing credit usage (Balance vs Deployments)
+- **Credit Balance** - Your remaining credits, days left in the trial, and usage
+- **Active Leases** - All your currently running deployments (max 1 day each during trial)
+- **Cost** - Real-time spending from your credits
+- **Balance** - Visual chart showing credit usage over time
 
 **Pro tip:** Hover over your balance at the top to see detailed credit information!
 
@@ -261,31 +180,40 @@ The Console dashboard shows:
 ## Common Questions
 
 ### "How long do trial deployments last?"
-**Answer:** Trial deployments last a maximum of **1 day (24 hours)**. After 24 hours, they will automatically shut down. This is a trial limitation - paid accounts can run indefinitely.
+**Answer:** Trial deployments last a maximum of **1 day (24 hours)**. After 24 hours, they automatically shut down—but you can redeploy as many times as you like within your 30-day trial. Adding credits removes the 24-hour limit.
 
-### "Can I use H100, H200, A100, RTX 4090, or RTX 5090 GPUs?"
-**Answer:** High-end GPUs (**H100**, **H200**, **A100**, **RTX 4090**, **RTX 5090**) are not available during the free trial. Add a payment method to switch to pay-as-you-go and unlock access to every GPU type on the network.
+### "Can I use high-end GPUs like the H100, H200, A100, or RTX 5090/4090?"
+**Answer:** High-end GPUs (such as the NVIDIA H100, H200, B200, A100, and RTX 5090/4090) aren't included in the free trial. Add credits to unlock them, along with longer runtimes and the full Console.
 
-### "What happens after my $100 credits run out?"
-**Answer:** Your deployments will stop, but you can add more funds via credit card:
+### "Do I need a credit card to start?"
+**Answer:** No. You get $1 in free trial credits with no card. You only add a card if you want to add credits, unlock high-end GPUs, or move to pay-as-you-go.
+
+### "Is there a bonus for adding credits?"
+**Answer:** Yes. On your first purchase of $100 or more, you get **10% in bonus credits, up to $100**. The minimum top-up is $20.
+
+### "How do I skip the trial and unlock the full Console?"
+**Answer:** Choose **"Skip the trial - unlock Console"** (or **"Add funds"** once you're in the app), add credits with a card, and you're on pay-as-you-go with longer runtimes and high-end GPU access.
+
+### "What happens after my trial credits run out?"
+**Answer:** Your deployments will stop, but you can add more funds anytime:
 1. Click your balance at the top
-2. Click **"Add Funds"**
-3. Enter amount and complete payment via Stripe (funds **ACT**)
-4. Your unused trial credits will be kept!
+2. Click **"Add funds"**
+3. Enter an amount and complete payment
+4. Your unused trial credits are kept!
 
 ### "Can I use my own crypto wallet instead?"
 **Answer:** Akash Console is the managed product and no longer accepts wallet connections. For self-custody — bring your own Keplr wallet, sign your own transactions, no time limits — use **[Console Air](https://github.com/akash-network/console-air)**, the self-hostable companion app. See [Choosing Your Console](/docs/getting-started/choosing-your-console) for a side-by-side comparison.
 
 ### "My deployment is taking a long time to start"
 **Solution:**
-- Wait 2-3 minutes - deployment can take time
+- Wait 1-2 minutes - deployment can take time
 - Check the status updates in Console
-- If stuck for 5+ minutes, close and try a different template
+- If stuck for several minutes, close and try a different template
 - Some GPU deployments take longer due to high demand
 
 ### "I don't see my deployment URL"
 **Solution:**
-- Wait until status shows **"Running"** (not just "Active")
+- Wait until your deployment is fully **running**
 - Click on your deployment to see details
 - Look for **"URIs"** or **"Leases"** section
 - The URL will be listed there once the container is fully running
@@ -297,20 +225,17 @@ The Console dashboard shows:
 - Check the **"Events"** or **"Logs"** tab for error messages
 - Contact support on Discord if issue persists
 
-### "$1 verification charge didn't refund yet"
-**Answer:** The $1 verification charge typically refunds within 3-7 business days, depending on your bank. This is standard practice for identity verification.
-
 ---
 
 ## What's Next?
 
 ### Maximize Your Trial
 
-You have $100 in credits and 30 days - here's how to make the most of it:
+You have free trial credits and 30 days - here's how to make the most of it:
 
-1. **Try the Templates** - Deploy ComfyUI (Stable Diffusion) or Llama (AI chat)
+1. **Try the Templates** - Deploy an image-generation or LLM template
 2. **Explore the Marketplace** - Browse pre-built solutions in the Templates section
-3. **Test Your Own Apps** - Use the SDL Builder to deploy your projects
+3. **Test Your Own Apps** - Deploy your own Docker image with the SDL Builder
 4. **Monitor Costs** - See how much different workloads cost on Akash
 
 ### Deploy Real Applications
@@ -335,7 +260,7 @@ Ready for more advanced workflows?
 
 ### Ready to Go Beyond Trial?
 
-**Add Funds:** Click your balance → "Add Funds" → Pay with credit card (keeps your $100 trial credits!)
+**Add Funds:** Click your balance → "Add funds" → Pay with a credit card (keeps your trial credits, and your first $100+ purchase earns a 10% bonus).
 
 **Want self-custody?** Use **[Console Air](https://github.com/akash-network/console-air)** — bring your own Keplr wallet, sign your own transactions, and remove the 24-hour limit.
 
@@ -356,10 +281,9 @@ We're here to help you succeed!
 
 - **Start with templates** - Use a featured template for your first deployment
 - **Watch your credits** - Monitor your balance at the top of Console
-- **Remember the 24-hour limit** - Trial deployments auto-close after 1 day
+- **Remember the 24-hour limit** - Trial deployments auto-close after 1 day (redeploy freely)
 - **Check logs first** - If something doesn't work, logs usually tell you why
-- **Explore the marketplace** - Browse pre-built solutions in Templates section
-- **Try different apps** - You have $100 to experiment with web apps, AI models, databases
-- **Add funds anytime** - Keep your trial credits when you add more via credit card
+- **Explore the marketplace** - Browse pre-built solutions in the Templates section
+- **Add funds anytime** - Keep your trial credits when you add more, and earn a 10% first-purchase bonus
 
 ---

--- a/src/content/Docs/getting-started/what-is-akash/index.md
+++ b/src/content/Docs/getting-started/what-is-akash/index.md
@@ -48,7 +48,7 @@ No single entity can shut down your application. Deploy anywhere, anytime.
 Access to high-end GPUs and compute at fraction of the cost. Perfect for AI/ML workloads.
 
 ### **Flexible Access**
-Start with our **trial** (credit card, $100 free credits in ACT, 30 days) or go **permissionless** with your own wallet (no KYC; fund deployments with **ACT**, or with AKT when the circuit breaker is in effect).
+Start with our **trial** ($1 in free USD credits, no credit card, 30 days) or go **permissionless** with your own wallet (no KYC; fund deployments with **ACT**, or with AKT when the circuit breaker is in effect).
 
 **Note:** Trial deployments have a 24-hour maximum duration per deployment, but you can redeploy as many times as you want within your 30-day trial period.
 
@@ -118,9 +118,9 @@ The **[Stack Definition Language (SDL)](/docs/developers/deployment/akash-sdl)**
 
 | Feature | Traditional Cloud | Akash - Trial | Akash - Wallet |
 |---------|------------------|---------------|----------------|
-| **Cost** | High, fixed pricing | $100 free credits | Up to 85% cheaper, market-driven |
-| **Access** | Credit card + KYC | Credit card (KYC for verification) | No KYC, permissionless |
-| **Payment** | Credit card monthly | Credit card (funds ACT) | Crypto (ACT; or AKT when circuit breaker) |
+| **Cost** | High, fixed pricing | $1 free trial credits | Up to 85% cheaper, market-driven |
+| **Access** | Credit card + KYC | No card required to start | No KYC, permissionless |
+| **Payment** | Credit card monthly | Credit card, USD credits | Crypto (ACT; or AKT when circuit breaker) |
 | **Setup** | Complicated | Sign up in 10 minutes | Install wallet, fund with ACT (or AKT when CB) |
 | **Deployment Limit** | None | 24 hours per deployment | None |
 | **Control** | Vendor lock-in | Choose your provider | Full blockchain control |
@@ -166,7 +166,7 @@ Reduce cloud costs significantly while scaling your application.
 Ready to deploy your first application on Akash? Choose your path:
 
 ### Managed (no wallet, pay with credit card)
-1. **[Akash Console](https://console.akash.network)** - Visual web interface with managed wallets; start with the [Quick Start free trial](/docs/getting-started/quick-start) and get $100 in credits
+1. **[Akash Console](https://console.akash.network)** - Visual web interface with managed wallets; start with the [Quick Start free trial](/docs/getting-started/quick-start) and get $1 in credits
 2. **[Console API](/docs/api-documentation/console-api)** - REST API for programmatic deployments with managed wallets
 
 ### Self-Custody (bring your own wallet)


### PR DESCRIPTION
## Summary

Updates the managed Akash Console getting-started docs to match the redesigned onboarding experience (feature flag `onboarding_redesign_v1`, live for 100% of new sign-ups). The public docs still described the **old** flow — a `$100` free trial, a mandatory credit card at sign-up, password sign-up, a "Start Free Trial" benefits page, manual escrow deposits in **ACT**, and manual provider-bid selection — none of which exist anymore.

Facts were verified against the live Console source (`apps/deploy-web` + `apps/api`).

## What changed

**Primary page** — `developers/deployment/akash-console/getting-started` — full rewrite to the new flow:
- Sign up with Google / GitHub / passwordless email (6-digit code), **no password, no card**, **$1** in free trial credits.
- Gated onboarding → "Let's deploy your first app" path picker (generic templates + Deploy-your-own-image).
- Automatic deposit (USD credits) + automatic provider matching on the guided path; auto-redirect when live.
- Free-trial limits ($1, 30-day window, 24h deployments, high-end GPUs excluded).
- "Skip the trial - unlock Console" → add credits (min $20) → pay-as-you-go, with the 10% first-purchase bonus (up to $100).
- Reframed the old "Quick Example" as **"Deploy your own app"** — the BYO-image path that genuinely uses the configure screen + manual provider selection.
- Common Tasks updated to current UI labels (Leases / Logs / Shell / Events / Update tabs).
- Purged all `$100`, ACT/escrow, AKT/circuit-breaker, and manual-deposit language from managed surfaces.

**Secondary pages** — fact fixes + corrected sign-up mechanics only (no restructure):
- `getting-started/quick-start` — `$100`→`$1`, removed mandatory-card + $1-verification-charge narrative, replaced password/CAPTCHA sign-up with passwordless, replaced the manual deploy steps with the gated path picker + auto funnel, refreshed FAQ/Tips (text-only).
- `getting-started/index`, `getting-started/what-is-akash`, `getting-started/core-concepts`, `getting-started/choosing-your-console`, `developers/deployment/akash-console/index`, `developers/deployment/index` — `$100`→`$1`, "no card required to start", USD credits, first-purchase bonus. Self-custody/wallet ACT references left intact where still accurate.

## Screenshots (⚠️ action needed)

The primary page adds placeholders for **4 new onboarding shots** (`onboarding-1-signup`, `onboarding-2-path-picker`, `onboarding-3-deploying`, `onboarding-4-skip-trial-credits`) plus concrete/`VERIFY` markers on likely-stale existing shots. These images need to be captured and dropped into `public/images/docs/console/` — they render broken until then. Every placeholder has an inline `<!-- SCREENSHOT: ... -->` / `<!-- VERIFY: ... -->` comment describing what to capture.

## Verification

- `npm run build` — clean, 587 pages built, no MDX/frontmatter errors.
- Stale-string grep across managed getting-started/console pages — no `$100` trial amount, "Start Free Trial", mandatory-card, escrow, or circuit-breaker references remain.

## Follow-up (not this PR)

De-duplicate the two managed-Console walkthroughs — make this primary page the single source of truth and trim Quick Start to a lean fast-path that links to it.

Refs CON-656
