### PR TITLE
fix: prevent /pricing/gpus crash from empty Select.Item value

### DIFF
--- a/src/components/pricing-page/gpus/filter.tsx
+++ b/src/components/pricing-page/gpus/filter.tsx
@@ -75,7 +75,7 @@ export default function Filter({
     setOptions((prev) => [
       {
         ...prev[0],
-        options: [...new Set(modal)]?.map((modal) => ({
+        options: [...new Set(modal)]?.filter(Boolean)?.map((modal) => ({
           name:
             modifyModel(modal).charAt(0).toUpperCase() +
             modifyModel(modal).slice(1),
@@ -85,12 +85,13 @@ export default function Filter({
       {
         ...prev[1],
         options: [...new Set(ram)]
+          ?.filter(Boolean)
           ?.map((ram) => ({ name: ram, value: ram }))
           ?.sort((a, b) => parseInt(b.name) - parseInt(a.name)),
       },
       {
         ...prev[2],
-        options: [...new Set(interfaceTypes)]?.map((interfaceType) => ({
+        options: [...new Set(interfaceTypes)]?.filter(Boolean)?.map((interfaceType) => ({
           name: interfaceType,
           value: interfaceType,
         })),
@@ -245,6 +246,8 @@ export default function Filter({
                   </SelectTrigger>
                   <SelectContent>
                     {item.options.map((option) => {
+                      // Radix <SelectItem> forbids an empty value; skip blanks defensively
+                      if (!option.value) return null;
                       const isSelected = filters[item.value].includes(
                         option.value,
                       );


### PR DESCRIPTION
## Problem

**https://akash.network/pricing/gpus/** white-screens in production:

```
Error: A <Select.Item /> must have a value prop that is not an empty string.
  at gpu-table.CxRAJGXZ.js:4:14896
```

The GPU table is a `client:load` React island, so this Radix throw crashes the whole island and blanks the page.

## Root cause

The filter dropdowns in `filter.tsx` are built directly from the API response (`GET console-api.akash.network/v1/gpu-prices`) with no sanitization. The live payload includes one model — **`l40s`** — with an empty `interface` field (`""`). That empty string flows straight into `<SelectItem value="">`, which **Radix Select v2 forbids** (empty value is reserved for clearing a selection) and throws on.

Prod-only because `gpu-table.tsx` serves clean `DUMMY_GPU_DATA` on any non-`akash.network` origin, so local/dev/preview never reproduce it.

## Fix (`src/components/pricing-page/gpus/filter.tsx`)

Two layers of defense:

1. **Source filter** — `.filter(Boolean)` on all three option arrays (Chipset / vRAM / Interface) so empty/null values never become dropdown options. Applied to all three (not just `interface`) to close the whole class of bug.
2. **Render guard** — `if (!option.value) return null` before rendering `SelectItem`, so no future data path can white-screen the page.

The `l40s` GPU still renders as a table row — only the unusable blank *filter* entry is removed (table rows come from `res.models`, not from the options array).

## Verification

- **Logic test against the real prod payload**: Interface options 5 (1 empty) → 4 (0 empty); Chipset/vRAM unaffected; no empty value reaches Radix.
- **`npm run build`**: 588 pages, no errors; fix present in the regenerated `gpu-table.*.js` bundle.