### PR TITLE
docs: modernize provider installation guides

### DIFF
--- a/DOCUMENTATION_AI_GUIDE.md
+++ b/DOCUMENTATION_AI_GUIDE.md
@@ -9,24 +9,28 @@
 ## Core Principles
 
 ### 1. Accuracy Over Speed
+
 - Verify all version numbers against official sources
 - Test all commands before documenting them
 - Never assume or hallucinate technical details
 - When uncertain, mark content for human verification
 
 ### 2. Clarity Over Cleverness
+
 - Use simple, direct language
 - Active voice preferred
 - No unnecessary jargon
 - Define technical terms on first use
 
 ### 3. Structure Over Style
+
 - Follow consistent patterns for similar content types
 - Use standard headings and organization
 - Maintain hierarchy (never skip heading levels)
 - Separate concerns (operators vs developers)
 
 ### 4. User Focus
+
 - Write for the specified audience (beginners vs experts)
 - Provide context before commands
 - Explain "why" before "how"
@@ -53,14 +57,14 @@ description: "SEO-friendly description for cards and search results"
 
 **Field Requirements:**
 
-| Field | Required | Type | Purpose | Example |
-|-------|----------|------|---------|---------|
-| `categories` | Yes | Array | Breadcrumb navigation | `["For Providers", "Setup & Installation"]` |
-| `tags` | No | Array | Related topics | `["Kubernetes", "GPU", "Hardware"]` |
-| `title` | Yes | String | H1 heading, SEO | `"Hardware Requirements"` |
-| `linkTitle` | No | String | Sidebar (if title too long) | `"Hardware"` |
-| `weight` | No | Number | Sidebar ordering (lower = higher) | `2` |
-| `description` | Yes | String | SEO, preview cards | `"Hardware specifications for providers"` |
+| Field         | Required | Type   | Purpose                           | Example                                     |
+| ------------- | -------- | ------ | --------------------------------- | ------------------------------------------- |
+| `categories`  | Yes      | Array  | Breadcrumb navigation             | `["For Providers", "Setup & Installation"]` |
+| `tags`        | No       | Array  | Related topics                    | `["Kubernetes", "GPU", "Hardware"]`         |
+| `title`       | Yes      | String | H1 heading, SEO                   | `"Hardware Requirements"`                   |
+| `linkTitle`   | No       | String | Sidebar (if title too long)       | `"Hardware"`                                |
+| `weight`      | No       | Number | Sidebar ordering (lower = higher) | `2`                                         |
+| `description` | Yes      | String | SEO, preview cards                | `"Hardware specifications for providers"`   |
 
 ### File Extension Rules
 
@@ -68,11 +72,13 @@ description: "SEO-friendly description for cards and search results"
 - `.mdx` - Markdown with React components (when using `<CodeTabs>`)
 
 **When to use `.mdx`:**
+
 - File imports React components (`CodeTabs`, custom components)
 - Multi-language code examples needed
 - Interactive elements required
 
 **When to use `.md`:**
+
 - All other documentation (95% of files)
 - Simple guides without code tabs
 - Conceptual content
@@ -131,7 +137,7 @@ description: "Brief description"
 
 ### Setup/Installation Guide Pattern
 
-```markdown
+````markdown
 ---
 title: "Installing [Component]"
 description: "Step-by-step guide to install [component]"
@@ -144,6 +150,7 @@ Brief description of what will be installed and why.
 ## Prerequisites
 
 Before starting, ensure you have:
+
 - Requirement 1
 - Requirement 2
 - Requirement 3
@@ -159,7 +166,9 @@ Brief explanation of what this step accomplishes.
 **On the [control plane/worker] node:**
 
 \```bash
+
 # Comment explaining command
+
 command-here
 \```
 
@@ -192,6 +201,7 @@ verification-command
 ### Issue: [Common Problem]
 
 **Symptoms:**
+
 - Symptom 1
 - Symptom 2
 
@@ -207,9 +217,10 @@ solution-command
 
 - [Link 1](/docs/...)
 - [Link 2](/docs/...)
-```
+````
 
 **Critical Elements:**
+
 - Number steps clearly: `STEP 1`, `STEP 2`, etc.
 - Include "Expected output" for non-obvious commands
 - Add verification commands after changes
@@ -234,6 +245,7 @@ Brief overview of the component's purpose and role.
 High-level explanation of the component.
 
 **Key responsibilities:**
+
 - Responsibility 1
 - Responsibility 2
 - Responsibility 3
@@ -267,6 +279,7 @@ How this component interacts with others.
 ```
 
 **Critical Elements:**
+
 - Focus on "how it works" not "how to use it"
 - Include source code references
 - Explain design decisions
@@ -275,12 +288,13 @@ How this component interacts with others.
 
 ### Troubleshooting Pattern
 
-```markdown
+````markdown
 ## Troubleshooting
 
 ### Issue: [Problem Name]
 
 **Symptoms:**
+
 - Observable symptom 1
 - Observable symptom 2
 
@@ -303,7 +317,7 @@ solution-command
 ### Issue: [Next Problem]
 
 [Repeat pattern]
-```
+````
 
 ---
 
@@ -312,14 +326,18 @@ solution-command
 ### Command Line Examples
 
 **Format:**
-```markdown
+
+````markdown
 \```bash
+
 # Explanatory comment
+
 command arg1 arg2
 \```
-```
+````
 
 **Rules:**
+
 - Always use `bash` language tag
 - Include explanatory comments for non-obvious commands
 - NO `$` prompts
@@ -328,24 +346,32 @@ command arg1 arg2
 - Show one logical action per code block
 
 **Example:**
-```markdown
+
+````markdown
 \```bash
+
 # Update package lists
+
 sudo apt update
 
 # Install required packages
+
 sudo apt install -y package1 package2
 \```
-```
+````
 
 **NOT:**
-```markdown
+
+````markdown
 \```
 $ sudo su
+
 # apt update
+
 # apt install package1
+
 \```
-```
+````
 
 ### Multi-Language Code Examples
 
@@ -354,6 +380,7 @@ $ sudo su
 **File must be `.mdx`**
 
 **Pattern:**
+
 ```typescript
 ---
 title: "API Example"
@@ -381,7 +408,7 @@ Brief explanation of the example.
 import (
     "context"
     "fmt"
-    
+
     "pkg.akt.dev/go/node/provider/v1"
 )
 
@@ -396,8 +423,8 @@ func main() {
       label: "TypeScript",
       code: `import { akash } from "@akashnetwork/chain-sdk";
 
-const queryClient = await akash.ClientFactory.createRPCQueryClient({ 
-  rpcEndpoint: "https://rpc.akash.network:443" 
+const queryClient = await akash.ClientFactory.createRPCQueryClient({
+  rpcEndpoint: "https://rpc.akash.network:443"
 });
 
 const response = await queryClient.akash.provider.v1.providers({});
@@ -427,20 +454,25 @@ console.log(response);`
 ### Configuration Files
 
 **Pattern:**
-```markdown
+
+````markdown
 \```yaml
+
 # filename.yaml
+
 key: value
 nested:
-  key: value
-  
+key: value
+
 # Comment explaining section
+
 section:
-  option: value
+option: value
 \```
-```
+````
 
 **Rules:**
+
 - Include filename as comment (first line)
 - Add comments for clarity
 - Show complete working examples when possible
@@ -456,45 +488,59 @@ section:
 **ALWAYS use these current versions. Do not hallucinate or guess.**
 
 #### Kubernetes Infrastructure
+
 - **Kubernetes:** `1.35.4` (via Kubespray 2.31.0)
 - **etcd:** `3.6.10`
 - **containerd:** `2.2.3`
 - **Calico CNI:** `3.31.5`
 
 #### Akash
-- **Akash Node:** `v1.1.0`
-- **Provider Services:** `v0.5.4+`
+
+- **Provider Playbook version source:** [`provider-playbooks/versions.yml`](https://github.com/akash-network/provider-playbooks/blob/main/versions.yml)
+- **`akt` CLI:** `v0.1.1`
+- **Provider:** `v0.16.2`
+- **Akash Node chart:** `18.0.0`
+- **Akash Gateway chart:** `1.2.1`
+- **Provider, Hostname Operator, and Inventory Operator charts:** `19.0.2`
 - **Omnibus Image:** `ghcr.io/akash-network/cosmos-omnibus:v1.2.35-akash-v1.1.0`
 - **Chain ID:** `akashnet-2`
 - **Gas Price:** `0.025uakt` (NOT 0.0025uakt - common error)
 
 #### GPU & Storage
-- **NVIDIA Driver:** `580` (recommended)
-- **NVIDIA Device Plugin:** `v0.18.0`
-- **NVIDIA CDI:** Strategy `cdi-cri` (NOT `nvidia-docker`)
-- **Rook-Ceph:** `v1.18.7`
+
+- **Helm:** `v4.2.4`
+- **NVIDIA GPU Operator:** `v26.7.0`
+- **NVIDIA Network Operator:** `v26.7.0`
+- **NVIDIA CDI:** Enabled; NRI enabled for the Provider Playbook's K3s mode
+- **Rook-Ceph:** `v1.19.10`
+- **Ceph:** `quay.io/ceph/ceph:v19.2.6-20260818`
 - **Cert-Manager:** `v1.19.1`
 
 #### Operating Systems
+
 - **Ubuntu:** `24.04 LTS` (only officially supported OS)
 
 #### Storage Classes
-- **beta1:** HDD (default, cheapest)
+
+- **beta1:** HDD
 - **beta2:** SSD (faster)
 - **beta3:** NVMe (fastest)
 - **ram:** SHM (NOT persistent storage)
 
 #### CLI Commands
-- **Deployments:** Use `provider-services tx deployment ...` (provider-services includes all akash CLI commands)
-- **Queries:** Use `provider-services query ...`
-- **Provider-Specific:** Use `provider-services` commands like `manifest`, `lease-status`, `lease-logs`
-- **Note:** `provider-services` is a superset of `akash` CLI - it includes all blockchain commands plus provider operations
+
+- **Deployments:** Use `akt deploy`, `akt update`, and `akt close`
+- **Queries and Transactions:** Use `akt query ...` and `akt tx ...`
+- **Provider Gateway Operations:** Use `akt provider ...`
+- **Keys:** Use `akt context keys ...`; network, keyring, and signer defaults belong to the active context
+- **Do not recommend:** The legacy `akash` or `provider-services` command-line interfaces
 
 ### When Versions Update
 
 If writing documentation and official versions have changed:
-1. Update this guide first
-2. Update all affected documentation
+
+1. Update the Provider Playbook's `versions.yml` compatibility matrix when the version is part of that automation
+2. Update this guide and all affected documentation
 3. Use `grep -r "old-version" src/content/Docs/` to find all occurrences
 4. Test with new versions before documenting
 
@@ -504,17 +550,18 @@ If writing documentation and official versions have changed:
 
 ### Emphasis Rules
 
-| Use Case | Syntax | Example |
-|----------|--------|---------|
-| Important terms | `**bold**` | `**Important:** Backup your keys` |
-| Commands | `` `backticks` `` | `kubectl get pods` |
-| File names | `` `backticks` `` | `provider.yaml` |
-| Paths | `` `backticks` `` | `/etc/kubernetes/manifests` |
-| Environment variables | `` `backticks` `` | `AKASH_HOME` |
-| Package names | `` `backticks` `` | `akash-node` |
-| Rare emphasis | `*italics*` | `*Optional:* Skip this step` |
+| Use Case              | Syntax            | Example                           |
+| --------------------- | ----------------- | --------------------------------- |
+| Important terms       | `**bold**`        | `**Important:** Backup your keys` |
+| Commands              | `` `backticks` `` | `kubectl get pods`                |
+| File names            | `` `backticks` `` | `provider.yaml`                   |
+| Paths                 | `` `backticks` `` | `/etc/kubernetes/manifests`       |
+| Environment variables | `` `backticks` `` | `AKASH_HOME`                      |
+| Package names         | `` `backticks` `` | `akash-node`                      |
+| Rare emphasis         | `*italics*`       | `*Optional:* Skip this step`      |
 
 **Never use:**
+
 - ALL CAPS for emphasis (except acronyms)
 - Underscores for emphasis
 - Excessive bold/italics
@@ -538,15 +585,16 @@ Use bold text for callouts (NOT HTML, NOT admonitions):
 
 **Callout Types:**
 
-| Type | Use Case | Example |
-|------|----------|---------|
-| `**Important:**` | Must-know information | Required configuration |
-| `**Note:**` | Additional context | Optional considerations |
-| `**Critical:**` | Security, data loss | Backup private keys |
-| `**Tip:**` | Helpful suggestions | Time-saving methods |
-| `**When Needed:**` | Conditional info | Alternative approaches |
+| Type               | Use Case              | Example                 |
+| ------------------ | --------------------- | ----------------------- |
+| `**Important:**`   | Must-know information | Required configuration  |
+| `**Note:**`        | Additional context    | Optional considerations |
+| `**Critical:**`    | Security, data loss   | Backup private keys     |
+| `**Tip:**`         | Helpful suggestions   | Time-saving methods     |
+| `**When Needed:**` | Conditional info      | Alternative approaches  |
 
 **Do NOT use:**
+
 - `:::danger` (doesn't render properly)
 - `:::warning` (doesn't render properly)
 - `:::info` (doesn't render properly)
@@ -556,11 +604,13 @@ Use bold text for callouts (NOT HTML, NOT admonitions):
 ### Link Standards
 
 **Internal Links:**
+
 ```markdown
 [Link Text](/docs/section/page)
 ```
 
 **Rules:**
+
 - ALWAYS start with `/docs/`
 - NO `index.md` in path
 - NO relative paths (`../`)
@@ -568,15 +618,17 @@ Use bold text for callouts (NOT HTML, NOT admonitions):
 - **Provider docs** in this repo use the `/docs/providers/...` path (e.g. `/docs/providers/setup-and-installation/kubespray/provider-installation`). Older examples may show `/docs/for-providers/...`; prefer `/docs/providers/...` for new and updated pages.
 
 **External Links:**
+
 ```markdown
 [Link Text](https://full-url.com)
 ```
 
 **Examples:**
+
 ```markdown
 ✅ GOOD: [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation)
-❌ BAD:  [Provider Installation](../provider-installation)
-❌ BAD:  [Provider Installation](/for-providers/.../provider-installation/index.md)
+❌ BAD: [Provider Installation](../provider-installation)
+❌ BAD: [Provider Installation](/for-providers/.../provider-installation/index.md)
 ```
 
 ---
@@ -588,6 +640,7 @@ Use bold text for callouts (NOT HTML, NOT admonitions):
 **Audience:** Complete beginners, no Akash experience
 
 **Requirements:**
+
 - Explain every step in detail
 - Define all technical terms
 - Focus on Akash Console (web UI, not CLI)
@@ -599,14 +652,16 @@ Use bold text for callouts (NOT HTML, NOT admonitions):
 **Tone:** Friendly, encouraging, patient
 
 **Example:**
+
 ```markdown
 ## What is a Deployment?
 
-A deployment is your application running on the Akash Network. When you 
-create a deployment, you're requesting compute resources (CPU, RAM, storage) 
+A deployment is your application running on the Akash Network. When you
+create a deployment, you're requesting compute resources (CPU, RAM, storage)
 from providers on the network.
 
 Think of it like renting a server, but:
+
 - Pay only for what you use (per-block pricing)
 - Choose from multiple providers bidding on your request
 - Your app runs in an isolated container
@@ -617,6 +672,7 @@ Think of it like renting a server, but:
 **Audience:** Developers integrating Akash
 
 **Requirements:**
+
 - Assume CLI/programming familiarity
 - Focus on concepts and integration patterns
 - Provide multi-language examples (curl, Go, TypeScript)
@@ -627,7 +683,8 @@ Think of it like renting a server, but:
 **Tone:** Professional, technical, concise
 
 **Example:**
-```markdown
+
+````markdown
 ## Query Providers via gRPC
 
 The provider query service returns all registered providers and their attributes.
@@ -640,20 +697,21 @@ res, _ := client.Providers(context.Background(), &provider.QueryProvidersRequest
 Filter by attribute:
 \```go
 req := &provider.QueryProvidersRequest{
-    Filters: &provider.ProviderFilters{
-        Attributes: []*v1beta3.Attribute{
-            {Key: "region", Value: "us-west"},
-        },
-    },
+Filters: &provider.ProviderFilters{
+Attributes: []\*v1beta3.Attribute{
+{Key: "region", Value: "us-west"},
+},
+},
 }
 \```
-```
+````
 
 ### For Providers (System Administrators)
 
 **Audience:** DevOps engineers, system administrators
 
 **Requirements:**
+
 - Assume Linux/Kubernetes knowledge
 - Be precise with commands and versions
 - Include all prerequisites
@@ -665,32 +723,40 @@ req := &provider.QueryProvidersRequest{
 **Tone:** Direct, technical, security-conscious
 
 **Example:**
-```markdown
+
+````markdown
 ## STEP 3: Configure Persistent Storage
 
 Install Rook-Ceph for persistent storage classes (beta1, beta2, beta3).
 
 **Prerequisites:**
-- Dedicated drives (not partitions) on each worker node
-- Minimum 4 SSDs or 2 NVMe SSDs across cluster
-- Drives must be unformatted
+
+- At least two dedicated physical disks across the cluster
+- One OSD per physical disk, including NVMe
+- Exact stable `/dev/disk/by-id` paths; never a broad wildcard
+- Three storage hosts recommended for production host-failure tolerance
+- Drives must be unpartitioned, unmounted, and free of signatures or LVM ownership
 
 \```bash
+
 # Verify available drives (should show no filesystem)
+
 lsblk -f
 
 # Expected: Empty FSTYPE column for target drives
+
 \```
 
-**Important:** Do not use system drives or shared partitions. Rook-Ceph 
+**Important:** Do not use system drives or shared partitions. Rook-Ceph
 requires exclusive access to raw block devices.
-```
+````
 
 ### For Node Operators (Blockchain Engineers)
 
 **Audience:** Blockchain node operators, validators
 
 **Requirements:**
+
 - Assume blockchain experience
 - Focus on node operations and security
 - Document upgrade procedures clearly
@@ -701,18 +767,21 @@ requires exclusive access to raw block devices.
 **Tone:** Technical, security-focused, precise
 
 **Example:**
+
 ```markdown
 ## Validator Security with TMKMS
 
-TMKMS (Tendermint Key Management System) separates your validator key 
+TMKMS (Tendermint Key Management System) separates your validator key
 from the node, adding a critical security layer.
 
 **Architecture:**
+
 - Validator node runs on Akash (no private key)
 - TMKMS runs on local machine (holds private key)
 - Stunnel provides encrypted communication
 
 **Security benefits:**
+
 - Private key never exposed to remote server
 - Double-signing protection (slashing prevention)
 - Hardware security module (HSM) support
@@ -725,6 +794,7 @@ from the node, adding a critical security layer.
 ### Architecture vs Operations
 
 **Architecture Documentation** (For Developers):
+
 - How code works internally
 - Service structure and design patterns
 - Integration points between services
@@ -732,13 +802,15 @@ from the node, adding a critical security layer.
 - Design rationale
 
 **Example:**
+
 ```markdown
 ## Bid Engine Architecture
 
-The Bid Engine monitors on-chain orders and generates bids based on 
+The Bid Engine monitors on-chain orders and generates bids based on
 available cluster resources.
 
 **Event Flow:**
+
 1. EventBus receives `OrderCreated` event
 2. Bid Engine validates order requirements
 3. Inventory Service provides available resources
@@ -749,19 +821,21 @@ available cluster resources.
 ```
 
 **Operations Documentation** (For Operators):
+
 - How to install/configure
 - How to monitor and troubleshoot
 - How to perform maintenance
 - What commands to run
 
 **Example:**
-```markdown
+
+````markdown
 ## Monitor Bid Activity
 
 Check bid submissions:
 
 \```bash
-provider-services query market bid list --provider=$(provider-services keys show provider -a)
+akt query market bid --by provider "$(akt context keys show provider --address)"
 \```
 
 View bid acceptance rate:
@@ -769,9 +843,10 @@ View bid acceptance rate:
 \```bash
 kubectl logs -n akash-services deployments/akash-provider -f | grep "bid-order"
 \```
-```
+````
 
 **NEVER mix these:**
+
 - Architecture docs should not have kubectl commands
 - Operations docs should not explain code internals
 - Keep them in separate sections
@@ -826,32 +901,38 @@ kubectl logs -n akash-services deployments/akash-provider -f | grep "bid-order"
 ### Technical Errors
 
 ❌ **Old gas prices:**
+
 ```markdown
-BAD:  --gas-prices 0.0025uakt
+BAD: --gas-prices 0.0025uakt
 GOOD: --gas-prices 0.025uakt
 ```
 
 ❌ **Wrong CLI commands:**
+
 ```markdown
-BAD:  provider-services tx deployment create
-GOOD: akash tx deployment create
+BAD: provider-services tx deployment create
+BAD: akash tx deployment create
+GOOD: akt deploy deployment.yaml --from <key>
 ```
 
 ❌ **Old Omnibus images:**
+
 ```markdown
-BAD:  cosmos-omnibus:v0.4.25-akash-v0.34.0
+BAD: cosmos-omnibus:v0.4.25-akash-v0.34.0
 GOOD: cosmos-omnibus:v1.2.35-akash-v1.1.0
 ```
 
 ❌ **Wrong chain ID:**
+
 ```markdown
-BAD:  akashnet-1
+BAD: akashnet-1
 GOOD: akashnet-2
 ```
 
 ### Structural Errors
 
 ❌ **Missing frontmatter:**
+
 ```markdown
 # Page Title
 
@@ -859,6 +940,7 @@ Content here...
 ```
 
 ✅ **Correct:**
+
 ```markdown
 ---
 categories: ["Section"]
@@ -870,14 +952,19 @@ Content here...
 ```
 
 ❌ **Missing horizontal rules:**
+
 ```markdown
 ## Section 1
+
 Content
+
 ## Section 2
+
 Content
 ```
 
 ✅ **Correct:**
+
 ```markdown
 ## Section 1
 
@@ -891,20 +978,25 @@ Content
 ```
 
 ❌ **Skipping heading levels:**
+
 ```markdown
 ## Section
+
 #### Subsection
 ```
 
 ✅ **Correct:**
+
 ```markdown
 ## Section
+
 ### Subsection
 ```
 
 ### Formatting Errors
 
 ❌ **Using admonitions:**
+
 ```markdown
 :::warning
 Important information
@@ -912,40 +1004,46 @@ Important information
 ```
 
 ✅ **Use bold text:**
+
 ```markdown
 **Important:** Important information
 ```
 
 ❌ **Relative links:**
+
 ```markdown
 [Link](../other-page)
 ```
 
 ✅ **Absolute links:**
+
 ```markdown
 [Link](/docs/section/other-page)
 ```
 
 ❌ **Command prompts:**
-```markdown
+
+````markdown
 \```bash
 $ sudo apt update
 $ sudo apt install package
 \```
-```
+````
 
 ✅ **Clean commands:**
-```markdown
+
+````markdown
 \```bash
 sudo apt update
 sudo apt install package
 \```
-```
+````
 
 ### Content Errors
 
 ❌ **Mixing audiences:**
-```markdown
+
+````markdown
 ## Architecture Overview
 
 The Bid Engine monitors orders...
@@ -954,20 +1052,23 @@ To view logs:
 \```bash
 kubectl logs ...
 \```
-```
+````
 
 ✅ **Separate concerns:**
+
 ```markdown
 Architecture doc: Explain how it works
 Operations doc: Show kubectl commands
 ```
 
 ❌ **Assuming without verifying:**
+
 ```markdown
 "The minimum RAM requirement is 0.5 GB"
 ```
 
 ✅ **Verify first:**
+
 ```markdown
 (Check actual minimums, then document accurately)
 ```
@@ -978,7 +1079,7 @@ Operations doc: Show kubectl commands
 
 ### Example 1: Setup Guide
 
-```markdown
+````markdown
 ---
 categories: ["For Providers", "Setup & Installation", "Kubespray"]
 tags: ["Kubernetes", "Installation", "Setup"]
@@ -995,6 +1096,7 @@ Set up a production-ready Kubernetes cluster using Kubespray.
 ## Prerequisites
 
 Before starting, ensure you have:
+
 - 3+ servers running Ubuntu 24.04 LTS
 - 8+ GB RAM per server
 - SSH access to all servers
@@ -1051,10 +1153,10 @@ kubectl get nodes
 
 **Expected output:**
 \```
-NAME     STATUS   ROLES           AGE   VERSION
-node1    Ready    control-plane   5m    v1.35.4
-node2    Ready    <none>          5m    v1.35.4
-node3    Ready    <none>          5m    v1.35.4
+NAME STATUS ROLES AGE VERSION
+node1 Ready control-plane 5m v1.35.4
+node2 Ready <none> 5m v1.35.4
+node3 Ready <none> 5m v1.35.4
 \```
 
 ---
@@ -1064,6 +1166,7 @@ node3    Ready    <none>          5m    v1.35.4
 ### Issue: Kubespray Fails to Deploy
 
 **Symptoms:**
+
 - Ansible playbook fails
 - Error: "Failed to download kubeadm"
 
@@ -1086,11 +1189,11 @@ curl -I https://github.com
 - [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support)
 - [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation)
 - [Hardware Requirements](/docs/providers/getting-started/hardware-requirements)
-```
+````
 
 ### Example 2: Architecture Document
 
-```markdown
+````markdown
 ---
 categories: ["For Providers", "Architecture"]
 tags: ["Architecture", "Cluster", "Kubernetes"]
@@ -1109,6 +1212,7 @@ The Cluster Service manages the Kubernetes lifecycle of tenant deployments.
 The Cluster Service acts as the bridge between Akash leases and Kubernetes resources.
 
 **Key responsibilities:**
+
 - Translate SDL manifests to Kubernetes resources
 - Monitor deployment health and resource usage
 - Enforce resource limits and quotas
@@ -1125,10 +1229,10 @@ The Cluster Service initializes with:
 \```go
 // cluster/service.go
 func NewService(ctx context.Context, client kubernetes.Interface) Service {
-    return &service{
-        client: client,
-        inventory: inventory.NewOperator(client),
-    }
+return &service{
+client: client,
+inventory: inventory.NewOperator(client),
+}
 }
 \```
 
@@ -1153,17 +1257,18 @@ The Cluster Service translates SDL service definitions to Kubernetes Deployments
 \```go
 // cluster/kube/builder/deployment.go
 func (b *deploymentBuilder) create() (*appsv1.Deployment, error) {
-    return &appsv1.Deployment{
-        ObjectMeta: b.buildObjectMeta(),
-        Spec: appsv1.DeploymentSpec{
-            Replicas: &b.replicas,
-            Template: b.buildPodTemplate(),
-        },
-    }, nil
+return &appsv1.Deployment{
+ObjectMeta: b.buildObjectMeta(),
+Spec: appsv1.DeploymentSpec{
+Replicas: &b.replicas,
+Template: b.buildPodTemplate(),
+},
+}, nil
 }
 \```
 
 **Key mappings:**
+
 - SDL `cpu` → Kubernetes `resources.requests.cpu`
 - SDL `memory` → Kubernetes `resources.requests.memory`
 - SDL `storage` → PersistentVolumeClaim
@@ -1174,14 +1279,17 @@ func (b *deploymentBuilder) create() (*appsv1.Deployment, error) {
 ## Integration Points
 
 **Upstream:**
+
 - Receives manifests from Manifest Service
 - Receives inventory queries from Bid Engine
 
 **Downstream:**
+
 - Deploys to Kubernetes API
 - Queries Inventory Operator for capacity
 
 **PubSub Events:**
+
 - Publishes `InventoryUpdate` on resource changes
 - Subscribes to `LeaseCreated` and `LeaseClosed`
 
@@ -1192,11 +1300,11 @@ func (b *deploymentBuilder) create() (*appsv1.Deployment, error) {
 - [Manifest Service Architecture](/docs/providers/architecture/manifest-service)
 - [Inventory Operator](/docs/providers/architecture/operators/inventory)
 - [Provider Service Overview](/docs/providers/architecture)
-```
+````
 
 ### Example 3: API Example with CodeTabs
 
-```markdown
+````markdown
 ---
 categories: ["For Developers", "API Protocols"]
 tags: ["API", "gRPC", "SDK"]
@@ -1219,6 +1327,7 @@ Akash exposes gRPC services for all blockchain queries and transactions.
 **Endpoint:** `grpc.akash.network:443`
 
 **Available services:**
+
 - Provider queries
 - Deployment lifecycle
 - Market operations
@@ -1231,63 +1340,64 @@ Akash exposes gRPC services for all blockchain queries and transactions.
 Retrieve all registered providers on the network.
 
 <CodeTabs
-  client:load
-  examples={[
-    {
-      language: "bash",
-      label: "grpcurl",
-      code: `grpcurl -d '{}' \\
+client:load
+examples={[
+{
+language: "bash",
+label: "grpcurl",
+code: `grpcurl -d '{}' \\
   grpc.akash.network:443 \\
   akash.provider.v1.Query/Providers`
-    },
-    {
-      language: "go",
-      code: `package main
+},
+{
+language: "go",
+code: `package main
 
 import (
-    "context"
-    "fmt"
-    
+"context"
+"fmt"
+
     "pkg.akt.dev/go/node/provider/v1"
     "google.golang.org/grpc"
+
 )
 
 func main() {
-    conn, _ := grpc.Dial("grpc.akash.network:443", grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
-    defer conn.Close()
-    
+conn, \_ := grpc.Dial("grpc.akash.network:443", grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+defer conn.Close()
+
     client := provider.NewQueryClient(conn)
     res, _ := client.Providers(context.Background(), &provider.QueryProvidersRequest{})
-    
+
     fmt.Printf("Found %d providers\\n", len(res.Providers))
-}`
-    },
+
+}`    },
     {
       language: "typescript",
       label: "TypeScript",
-      code: `import { akash } from "@akashnetwork/chain-sdk";
+      code:`import { akash } from "@akashnetwork/chain-sdk";
 
-const queryClient = await akash.ClientFactory.createRPCQueryClient({ 
-  rpcEndpoint: "https://rpc.akash.network:443" 
+const queryClient = await akash.ClientFactory.createRPCQueryClient({
+rpcEndpoint: "https://rpc.akash.network:443"
 });
 
 const response = await queryClient.akash.provider.v1.providers({});
 console.log(\`Found \${response.providers.length} providers\`);`
-    }
-  ]}
+}
+]}
 />
 
 **Response:**
 
 \```json
 {
-  "providers": [
-    {
-      "owner": "akash1...",
-      "host_uri": "https://provider.example.com",
-      "attributes": [...]
-    }
-  ]
+"providers": [
+{
+"owner": "akash1...",
+"host_uri": "https://provider.example.com",
+"attributes": [...]
+}
+]
 }
 \```
 
@@ -1298,12 +1408,12 @@ console.log(\`Found \${response.providers.length} providers\`);`
 Query providers with specific attributes (e.g., region, GPU capabilities).
 
 <CodeTabs
-  client:load
-  examples={[
-    {
-      language: "bash",
-      label: "grpcurl",
-      code: `grpcurl -d '{
+client:load
+examples={[
+{
+language: "bash",
+label: "grpcurl",
+code: `grpcurl -d '{
   "filters": {
     "attributes": [
       {"key": "region", "value": "us-west"}
@@ -1312,31 +1422,30 @@ Query providers with specific attributes (e.g., region, GPU capabilities).
 }' \\
   grpc.akash.network:443 \\
   akash.provider.v1.Query/Providers`
-    },
-    {
-      language: "go",
-      code: `req := &provider.QueryProvidersRequest{
-    Filters: &provider.ProviderFilters{
-        Attributes: []*v1beta3.Attribute{
-            {Key: "region", Value: "us-west"},
-        },
-    },
+},
+{
+language: "go",
+code: `req := &provider.QueryProvidersRequest{
+Filters: &provider.ProviderFilters{
+Attributes: []\*v1beta3.Attribute{
+{Key: "region", Value: "us-west"},
+},
+},
 }
 
-res, _ := client.Providers(context.Background(), req)`
-    },
+res, \_ := client.Providers(context.Background(), req)`    },
     {
       language: "typescript",
       label: "TypeScript",
-      code: `const response = await queryClient.akash.provider.v1.providers({
-  filters: {
-    attributes: [
-      { key: "region", value: "us-west" }
-    ]
-  }
+      code:`const response = await queryClient.akash.provider.v1.providers({
+filters: {
+attributes: [
+{ key: "region", value: "us-west" }
+]
+}
 });`
-    }
-  ]}
+}
+]}
 />
 
 ---
@@ -1346,7 +1455,7 @@ res, _ := client.Providers(context.Background(), req)`
 - [REST API](/docs/for-developers/api-protocols/rest-api)
 - [RPC Endpoints](/docs/for-developers/api-protocols/rpc-endpoints)
 - [Akash SDK](/docs/for-developers/deployment/akash-sdk)
-```
+````
 
 ---
 
@@ -1419,12 +1528,14 @@ Then provide:
 **This guide is updated:** December 3, 2024
 
 **When to update this guide:**
+
 - Official version numbers change
 - New components added (e.g., new operator)
 - Documentation patterns change
 - New features require new patterns
 
 **How to update:**
+
 1. Update version table
 2. Update examples if needed
 3. Update patterns if needed
@@ -1438,9 +1549,9 @@ Then provide:
 **IMPORTANT:** Akash Network does **NOT** have a forum. Do not add forum links to documentation.
 
 **Official Support Channels:**
+
 - **Discord:** [discord.akash.network](https://discord.akash.network) - Primary community support
 - **GitHub:** [github.com/akash-network](https://github.com/akash-network) - Issues and discussions
 - **Documentation:** This website
 
 **Questions?** Contact the documentation team via Discord #docs channel or open an issue on GitHub.
-

--- a/src/content/Docs/providers/architecture/manifest-service/index.md
+++ b/src/content/Docs/providers/architecture/manifest-service/index.md
@@ -32,16 +32,16 @@ type service struct {
     session session.Session
     bus     pubsub.Bus
     sub     pubsub.Subscriber
-    
+
     statusch      chan chan<- *Status
     mreqch        chan manifestRequest
     activeCheckCh chan isActiveCheck
-    
+
     managers  map[string]*manager
     managerch chan *manager
-    
+
     hostnameService HostnameServiceClient
-    
+
     watchdogs  map[DeploymentID]*watchdog
     watchdogch chan DeploymentID
 }
@@ -77,7 +77,7 @@ manifest, err := manifest.NewService(
 
 ```yaml
 # provider.yaml
-manifest-timeout: 5m  # Time to wait for manifest before closing lease
+manifest-timeout: 5m # Time to wait for manifest before closing lease
 ```
 
 **Configuration Parameters:**
@@ -97,11 +97,12 @@ case event.LeaseWon:
     if ev.LeaseID.GetProvider() != s.session.Provider().Address() {
         continue  // Not for this provider
     }
-    
+
     s.handleLease(ev, true)
 ```
 
 **Process:**
+
 1. Verify lease is for this provider
 2. Create watchdog if `manifest-timeout` configured
 3. Create or retrieve manifest manager for deployment
@@ -117,12 +118,13 @@ If `manifest-timeout` is set, a watchdog is created:
 type watchdog struct {
     LeaseID        LeaseID
     ManifestTimeout time.Duration
-    
+
     timer *time.Timer
 }
 ```
 
 **Watchdog Behavior:**
+
 ```go
 // Start timer when lease won
 timer := time.NewTimer(manifestTimeout)
@@ -146,6 +148,7 @@ Tenant submits manifest via HTTP POST to provider:
 **HTTP Endpoint**: `PUT /deployment/{owner}/{dseq}/manifest`
 
 **Request:**
+
 ```yaml
 # Headers
 Authorization: Bearer <jwt-token>
@@ -191,20 +194,20 @@ func createManifestHandler(log log.Logger, mclient Client) http.HandlerFunc {
     return func(w http.ResponseWriter, req *http.Request) {
         // 1. Parse request
         deploymentID := requestDeploymentID(req)
-        
+
         // 2. Decode manifest
         var mani manifest.Manifest
         err := DecodeYAML(req.Body, &mani)
-        
+
         // 3. Submit to manifest service
         err = mclient.Submit(subctx, deploymentID, mani)
-        
+
         // 4. Return response
         if err != nil {
             http.Error(w, err.Error(), http.StatusUnprocessableEntity)
             return
         }
-        
+
         w.WriteHeader(http.StatusOK)
     }
 }
@@ -218,7 +221,7 @@ The manifest service validates the submitted manifest:
 func (s *service) Submit(ctx context.Context, did DeploymentID, mani Manifest) error {
     // 1. Validate manifest structure
     err := mani.Validate()
-    
+
     // 2. Check hostname availability
     for _, service := range mani.Services {
         for _, expose := range service.Expose {
@@ -230,7 +233,7 @@ func (s *service) Submit(ctx context.Context, did DeploymentID, mani Manifest) e
             }
         }
     }
-    
+
     // 3. Send to manager for processing
     s.mreqch <- manifestRequest{
         DeploymentID: did,
@@ -240,6 +243,7 @@ func (s *service) Submit(ctx context.Context, did DeploymentID, mani Manifest) e
 ```
 
 **Validation Steps:**
+
 1. **Structure Validation** - Verify YAML syntax and required fields
 2. **Resource Validation** - Ensure resources match lease
 3. **Hostname Validation** - Check hostname availability
@@ -254,20 +258,21 @@ The manifest manager processes the validated manifest:
 ```go
 type manager struct {
     daddr       DeploymentID
-    
+
     config      ServiceConfig
     session     Session
     bus         Bus
-    
+
     leasech     chan event.LeaseWon
     runch       <-chan runner.Result
     manifestch  chan submitRequest
-    
+
     hostnameService HostnameServiceClient
 }
 ```
 
 **Process:**
+
 1. Parse manifest groups
 2. Validate resources against lease
 3. Validate hostnames
@@ -277,11 +282,11 @@ type manager struct {
 func (m *manager) handleManifest(req submitRequest) error {
     // 1. Get manifest group for this lease
     group := req.Manifest.GetGroup(m.lease.GroupSpec.Name)
-    
+
     // 2. Validate hostnames
     hostnames := extractHostnames(group)
     err := m.hostnameService.CanReserveHostnames(hostnames, m.lease.Owner)
-    
+
     // 3. Emit event
     m.bus.Publish(event.ManifestReceived{
         LeaseID:        m.lease,
@@ -304,6 +309,7 @@ event.ManifestReceived{
 ```
 
 **Subscribers:**
+
 - **Cluster Service** - Creates Kubernetes deployment
 - **Bid Engine** - Updates lease tracking
 - **Provider Service** - Logs event
@@ -320,7 +326,7 @@ case req := <-m.manifestch:
         watchdog.stop()
         delete(s.watchdogs, m.daddr)
     }
-    
+
     // Process manifest
     m.handleManifest(req)
 ```
@@ -359,23 +365,16 @@ Manager Removed
 
 ## Manifest Updates
 
-Tenants can update their deployment by submitting a new manifest:
+Tenants can update a deployment and send its new manifest with one `akt` workflow:
 
 ```bash
-# Tenant sends updated manifest
-akash tx deployment update update.yaml \
-  --from mykey \
-  --node https://rpc.akashnet.net:443
-
-# Then sends manifest to provider again
-akash provider send-manifest update.yaml \
-  --dseq 123456 \
-  --provider <provider-address>
+akt update update.yaml 123456 --from mykey
 ```
 
 **Update Process:**
-1. Tenant updates on-chain deployment
-2. Tenant submits new manifest to provider
+
+1. `akt` updates the on-chain deployment
+2. `akt` submits the new manifest to all active lease providers
 3. Manifest service validates changes
 4. Emits `ManifestReceived` event
 5. Cluster service performs rolling update
@@ -417,28 +416,33 @@ log.Info("manifest timeout", "lease", leaseID, "timeout", manifestTimeout)
 The watchdog system solves a resource reservation problem:
 
 **Problem**: Tenant wins lease but never sends manifest
+
 - Cluster resources remain reserved
 - Inventory shows resources as unavailable
 - Provider cannot bid on other deployments
 
 **Solution**: Watchdog timer closes lease after timeout
+
 - Resources returned to available inventory
 - Lease closed on-chain
 - Provider can accept new bids
 
 **Configuration**: `manifest-timeout` in `provider.yaml`
+
 - Set to `5m` for standard timeout
 - Set to `0` to disable (wait indefinitely)
 
 ## Source Code Reference
 
 **Primary Implementation**:
+
 - `manifest/service.go` - Main manifest service
 - `manifest/manager.go` - Per-deployment manager
 - `manifest/watchdog.go` - Timeout monitoring
 - `gateway/rest/router.go` - HTTP endpoints and handlers
 
 **Key Functions**:
+
 - `NewService()` - Initialize manifest service
 - `Submit()` - Accept manifest from tenant
 - `handleLease()` - Process lease won event

--- a/src/content/Docs/providers/getting-started/hardware-requirements/index.md
+++ b/src/content/Docs/providers/getting-started/hardware-requirements/index.md
@@ -16,10 +16,12 @@ This guide covers system requirements, hardware specifications, and best practic
 ## System Requirements
 
 ### Operating System
+
 - **Ubuntu 24.04 LTS Server** (officially supported)
 - Ensure all nodes are fully updated with latest security patches
 
 ### CPU Architecture
+
 - **x86_64 processors only** (officially supported)
 - ARM processors are **not currently supported**
 - Applies to all nodes in the cluster
@@ -31,16 +33,19 @@ This guide covers system requirements, hardware specifications, and best practic
 ### Single Server (Worker + Control Plane Combined)
 
 **Minimum:**
+
 - CPU: 8 cores
 - RAM: 16GB
 - Storage: 150GB SSD
 
 **Recommended:**
+
 - CPU: 12+ cores
 - RAM: 48+ GB
 - Storage: 500GB+ SSD
 
 **Important Considerations:**
+
 - Reserve ~4 CPU cores for Kubernetes system components (control plane + worker overhead)
 - Single server setup is good for testing or small providers
 - For production, separate control plane and worker nodes are recommended
@@ -48,32 +53,38 @@ This guide covers system requirements, hardware specifications, and best practic
 ### Control Plane Node (per node, separate setup)
 
 **Minimum:**
+
 - CPU: 2 cores
 - RAM: 4GB
 - Storage: 30GB SSD
 
 **Recommended:**
+
 - CPU: 4 cores
 - RAM: 8GB
 - Storage: 40GB SSD
 
 **For Production (3-node control plane):**
+
 - 3x control plane nodes for high availability
 - Total: 12 CPU cores, 24GB RAM, 120GB storage
 
 ### Worker Node (per node, separate setup)
 
 **Minimum:**
+
 - CPU: 4 cores
 - RAM: 8GB
 - Storage: 100GB SSD
 
 **Recommended:**
+
 - CPU: 8+ cores
 - RAM: 32+ GB
 - Storage: 500GB+ SSD
 
 **Important Considerations:**
+
 - Reserve ~2 CPU cores for Kubernetes system components
 - More resources = more concurrent deployments
 - **Example:** 8 CPU node = ~6 deployments (8 CPU - 2 reserved)
@@ -83,20 +94,24 @@ This guide covers system requirements, hardware specifications, and best practic
 ## GPU Requirements
 
 ### Supported GPUs
+
 - **NVIDIA GPUs only** currently supported
 
 ### GPU Requirements & Best Practices
 
 **One GPU Type Per Node (Required):**
+
 - Each node **must** have only **one type of GPU**
 - Mixing different GPU models on the same node is **not supported**
 - Multiple identical GPUs per node is supported and recommended
 
 **One GPU Type Per Provider (Recommended):**
+
 - While technically possible to have different GPU types across nodes, it is **strongly recommended** to standardize on one GPU type per provider
 - Having multiple GPU types in one provider (on different nodes) can complicate operations and pricing
 
 **Example Configurations:**
+
 - **AI/ML Node:** 4x NVIDIA A100 (all identical)
 - **Rendering Node:** 2x RTX 4090 (all identical)
 - **Mixed Workload:** 8x T4 (all identical)
@@ -106,6 +121,7 @@ This guide covers system requirements, hardware specifications, and best practic
 ## Storage Guidelines
 
 ### Root/Ephemeral Storage
+
 - **Minimum:** 100GB per worker node
 - **Recommended:** 500GB+ per worker node
 - **Type:** SSD or NVMe for performance
@@ -113,25 +129,29 @@ This guide covers system requirements, hardware specifications, and best practic
 ### Persistent Storage (Optional)
 
 **Minimum Requirements:**
-- **Recommended (default in [Persistent Storage](/docs/providers/setup-and-installation/kubespray/persistent-storage)):** 2+ NVMe SSDs across all nodes (`beta3`)
-- **Alternative:** 4 SATA/SAS SSDs across all nodes (`beta2`)
-- All persistent storage must be **same type** across entire cluster
-- **Do not mix** storage types (e.g., SSD + NVMe, or beta2 + beta3)
+
+- At least **two dedicated physical disks** across the cluster
+- One Ceph OSD per physical disk, including NVMe
+- For production host-failure tolerance, dedicated disks on at least **three storage hosts**
+- Homogeneous media are preferred. Mixed media are supported, but the provider must advertise the slowest selected tier.
 
 **Dedicated Drives:**
+
 - These drives must be **dedicated exclusively** to persistent storage
 - Cannot be used for any other purpose (no OS, no ephemeral storage)
 - **Recommended:** Distribute dedicated drives across multiple nodes for redundancy
 
 **Storage Classes:**
-- `beta3` - NVMe (Non-Volatile Memory Express) — **default**
+
+- `beta3` - NVMe (Non-Volatile Memory Express)
 - `beta2` - SSD (Solid State Drive)
 - `beta1` - HDD (Hard Disk Drive)
 
 **Example Configurations:**
-- **Minimum NVMe (recommended):** 2x 2TB NVMe drives across 2 nodes (`beta3`)
-- **Minimum SSD:** 4x 1TB SSDs across 2-4 nodes (`beta2`)
-- **Recommended:** 6+ NVMe drives distributed across 3+ nodes for better redundancy
+
+- **Technical minimum:** 2 dedicated disks on one or two hosts; a one-host layout has no host-level availability
+- **Production baseline:** 3+ dedicated disks distributed across 3+ hosts
+- **Higher capacity:** Multiple disks per host, with one OSD created for each physical disk
 
 ---
 
@@ -140,11 +160,13 @@ This guide covers system requirements, hardware specifications, and best practic
 ### Internet Connection
 
 **Bandwidth:**
+
 - **Minimum:** 100 Mbps symmetrical
 - **Recommended:** 1+ Gbps symmetrical
 - **Critical:** Upload speed matters as much as download
 
 **Latency:**
+
 - Low latency preferred (< 10ms to major hubs)
 - Affects bid competitiveness
 - Important for real-time workloads
@@ -152,10 +174,12 @@ This guide covers system requirements, hardware specifications, and best practic
 ### IP Addressing
 
 **Required:**
+
 - **Option 1:** At least one static public IP
 - **Option 2:** Dynamic DNS (DDNS) service
 
 **Optional (for IP leases feature):**
+
 - Multiple static IPs
 - /29 subnet or larger
 - Allows providers to offer dedicated IPs to tenants
@@ -163,6 +187,7 @@ This guide covers system requirements, hardware specifications, and best practic
 ### Domain Name (Required)
 
 **You must own a domain name for your Akash provider:**
+
 - A registered domain that you control (e.g., `yourdomain.com`)
 - Used for provider identification and workload routing
 - DNS A records will point to your provider's public IP
@@ -170,6 +195,7 @@ This guide covers system requirements, hardware specifications, and best practic
 ### Firewall Rules
 
 **Required Open Ports:**
+
 - `80/tcp` - HTTP workloads
 - `443/tcp` - HTTPS workloads
 - `8443/tcp` - Manifest uploads
@@ -178,12 +204,14 @@ This guide covers system requirements, hardware specifications, and best practic
 - `30000-32767/udp` - Kubernetes NodePort range (UDP services)
 
 **Recommended:**
+
 - `22/tcp` - SSH (restrict to your IPs)
 - `6443/tcp` - Kubernetes API (control plane only, restrict to cluster nodes)
 
 ### Internal Network
 
 **For Multi-Node Clusters:**
+
 - Low-latency network between nodes (< 1ms)
 - 10 Gbps+ recommended for storage traffic
 
@@ -192,11 +220,14 @@ This guide covers system requirements, hardware specifications, and best practic
 ## Cluster Sizing Examples
 
 ### Small Provider (Home Lab)
+
 **Hardware:**
+
 - 1 control plane node: 4 CPU, 8GB RAM, 100GB SSD
 - 1 worker node: 8 CPU, 32GB RAM, 500GB SSD
 
 **Capacity:**
+
 - ~6 concurrent deployments
 - No GPU support
 - 100-200GB ephemeral storage
@@ -206,11 +237,14 @@ This guide covers system requirements, hardware specifications, and best practic
 ---
 
 ### Medium Provider (Small Data Center)
+
 **Hardware:**
+
 - 3 control plane nodes: 4 CPU, 8GB RAM, 100GB SSD each
 - 3 worker nodes: 16 CPU, 64GB RAM, 1TB SSD each
 
 **Capacity:**
+
 - ~40 concurrent deployments
 - Optional: 1-2 GPUs per worker
 - 1TB+ persistent storage
@@ -220,12 +254,15 @@ This guide covers system requirements, hardware specifications, and best practic
 ---
 
 ### Large Provider (Data Center)
+
 **Hardware:**
+
 - 3 control plane nodes: 8 CPU, 16GB RAM, 200GB SSD each
 - 10+ worker nodes: 32 CPU, 128GB RAM, 2TB NVMe each
 - Dedicated GPU nodes: 8 CPU, 64GB RAM, 4x A100 GPUs
 
 **Capacity:**
+
 - 200+ concurrent deployments
 - 20+ GPU instances
 - 10TB+ persistent storage
@@ -237,5 +274,5 @@ This guide covers system requirements, hardware specifications, and best practic
 ## Next Steps
 
 Calculate earnings:
-- [Provider Earn Calculator →](https://akash.network/pricing/provider-calculator/)
 
+- [Provider Earn Calculator →](https://akash.network/pricing/provider-calculator/)

--- a/src/content/Docs/providers/operations/gateway-api-migration/index.md
+++ b/src/content/Docs/providers/operations/gateway-api-migration/index.md
@@ -1,6 +1,14 @@
 ---
 categories: ["Providers", "Operations"]
-tags: ["Gateway API", "NGINX Gateway Fabric", "Migration", "Networking", "Kubernetes", "cert-manager"]
+tags:
+  [
+    "Gateway API",
+    "NGINX Gateway Fabric",
+    "Migration",
+    "Networking",
+    "Kubernetes",
+    "cert-manager",
+  ]
 weight: 3
 title: "Gateway API migration"
 linkTitle: "Gateway API migration"
@@ -44,7 +52,7 @@ kubectl -n akash-gateway describe certificate wildcard-ingress
 
 - [Prerequisites](#prerequisites) satisfied (or you will complete [TLS migration to Gateway API](/docs/providers/operations/tls-gateway-api-migration) in parallel)
 - Provider on v0.11.2 before upgrading to v0.12.0
-- `kubectl` and Helm 3
+- `kubectl` and Helm 4
 - `ingress-nginx` on TCP 8443 and 8444 today
 - Host ports 80, 443, 8443, 8444, and 5002 available on your nodes
 - cert-manager and a `ClusterIssuer` (as required by the prerequisite step)
@@ -237,14 +245,17 @@ for i in $(helm list -n akash-services -q | grep -vw akash-node); do helm -n aka
 ### Upgrade Operators
 
 ```bash
-helm -n akash-services upgrade akash-hostname-operator akash/akash-hostname-operator
-helm -n akash-services upgrade inventory-operator akash/akash-inventory-operator
+helm -n akash-services upgrade akash-hostname-operator akash/akash-hostname-operator \
+  --version 16.0.0
+helm -n akash-services upgrade inventory-operator akash/akash-inventory-operator \
+  --version 16.0.0
 ```
 
 **With persistent storage** (adjust storage class to match your setup):
 
 ```bash
 helm -n akash-services upgrade inventory-operator akash/akash-inventory-operator \
+  --version 16.0.0 \
   --set inventoryConfig.cluster_storage[0]=default \
   --set inventoryConfig.cluster_storage[1]=beta3 \
   --set inventoryConfig.cluster_storage[2]=ram
@@ -253,7 +264,8 @@ helm -n akash-services upgrade inventory-operator akash/akash-inventory-operator
 **With IP leasing (MetalLB):**
 
 ```bash
-helm -n akash-services upgrade akash-ip-operator akash/akash-ip-operator
+helm -n akash-services upgrade akash-ip-operator akash/akash-ip-operator \
+  --version 16.0.0
 ```
 
 ### Upgrade Provider
@@ -263,6 +275,7 @@ cd /root/provider
 
 helm upgrade akash-provider akash/provider \
   -n akash-services \
+  --version 16.0.0 \
   -f provider.yaml \
   --set bidpricescript="$(cat price_script.sh | openssl base64 -A)"
 ```
@@ -345,6 +358,7 @@ Each port should appear only once, owned by the NGINX Gateway Fabric process.
 ### Issue: Gateway Shows `Programmed: False`
 
 **Symptoms:**
+
 - `kubectl get gateway akash-gateway` shows `PROGRAMMED: False`
 - TCPRoutes remain unresolved
 
@@ -370,6 +384,7 @@ If the `GatewayClass` is missing, the Helm install may have failed. Re-run the H
 ### Issue: TCPRoute `ResolvedRefs` is `False`
 
 **Symptoms:**
+
 - `kubectl describe tcproute akash-provider-8443` shows backend not found
 
 **Diagnosis:**
@@ -393,6 +408,7 @@ The service must have ports 8443 and 8444 defined.
 ### Issue: Port Conflict on Node
 
 **Symptoms:**
+
 - NGINX Gateway Fabric pods fail to start or crash-loop
 - Error in pod logs: `bind: address already in use`
 
@@ -430,4 +446,3 @@ helm uninstall ingress-nginx -n ingress-nginx
 - [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)
 
 ---
-

--- a/src/content/Docs/providers/operations/gpu-operator-migration/index.md
+++ b/src/content/Docs/providers/operations/gpu-operator-migration/index.md
@@ -1,6 +1,14 @@
 ---
 categories: ["Providers", "Operations"]
-tags: ["GPU", "NVIDIA GPU Operator", "Migration", "Drivers", "Kubernetes", "Maintenance"]
+tags:
+  [
+    "GPU",
+    "NVIDIA GPU Operator",
+    "Migration",
+    "Drivers",
+    "Kubernetes",
+    "Maintenance",
+  ]
 weight: 5
 title: "GPU Operator migration"
 linkTitle: "GPU Operator migration"
@@ -21,7 +29,7 @@ Migrate if you want a single, versioned source of truth for the GPU stack, simpl
 
 ## Prerequisites
 
-- Cluster admin (`kubectl`) and Helm 3 on the control plane.
+- Cluster admin (`kubectl`) and Helm 4 on the control plane.
 - A maintenance window, or enough spare capacity to drain GPU nodes one at a time.
 - Nodes were set up with the **manual** GPU workflow: a host NVIDIA driver, the NVIDIA Container Toolkit, and a standalone `nvidia-device-plugin` Helm release.
 
@@ -118,21 +126,27 @@ sudo reboot
 
 After reboot, `nvidia-smi` on the host should report **"command not found"** or no driver — that clean state is what lets the Operator manage the driver.
 
-> **containerd runtime:** the GPU Operator's toolkit reconfigures containerd for the `nvidia` runtime. If you previously added an `nvidia` runtime via [Kubespray Setup – Step 7](/docs/providers/setup-and-installation/kubespray/kubernetes-setup#step-7---configure-gpu-support-optional) pointing at the host binary `/usr/bin/nvidia-container-runtime`, you may remove that entry for cleanliness once the Operator is running, but it is not required — the Operator's configuration takes precedence on managed nodes.
+> **containerd runtime:** If the old setup added `containerd_additional_runtimes` pointing at the host's `/usr/bin/nvidia-container-runtime`, remove that Kubespray override during migration. GPU Operator 26.7 manages CDI and the required containerd integration; current [Kubernetes setup guidance](/docs/providers/setup-and-installation/kubespray/kubernetes-setup#step-7---prepare-for-gpu-support-optional) does not add the legacy runtime.
 
 ## Step 4 — Install the GPU Operator
 
-Once your GPU nodes are clean, install the Operator cluster-wide. Use the same values as a fresh setup — see [GPU & InfiniBand Support → Step 2](/docs/providers/setup-and-installation/kubespray/gpu-support#step-2--install-the-gpu-operator) for the full file, Fabric Manager guidance, CRD notes, and pinned chart version (`v26.3.3`).
+Once your GPU nodes are clean, install the Operator cluster-wide. Use the same values as a fresh setup — see [GPU & InfiniBand Support → Step 2](/docs/providers/setup-and-installation/kubespray/gpu-support#step-2--install-the-gpu-operator) for the full file, Fabric Manager guidance, CRD procedure, and pinned chart version (`v26.7.0`).
 
 ```bash
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
 helm repo update
 
-# First deploy: helm install (not upgrade -i) so chart CRDs are applied
-helm install gpu-operator nvidia/gpu-operator \
+rm -rf /tmp/akash-gpu-operator-chart
+helm pull nvidia/gpu-operator --version v26.7.0 --untar \
+  --untardir /tmp/akash-gpu-operator-chart
+kubectl apply --server-side --force-conflicts \
+  -f /tmp/akash-gpu-operator-chart/gpu-operator/crds \
+  -f /tmp/akash-gpu-operator-chart/gpu-operator/charts/node-feature-discovery/crds/nfd-api-crds.yaml
+
+helm upgrade --install gpu-operator nvidia/gpu-operator \
   --namespace gpu-operator \
   --create-namespace \
-  --version v26.3.3 \
+  --version v26.7.0 \
   -f gpu-operator-values.yaml
 ```
 
@@ -140,11 +154,11 @@ Key values for migration:
 
 ```yaml
 driver:
-  enabled: true          # Operator installs the driver in a container
+  enabled: true # Operator installs the driver in a container
   rdma:
-    enabled: false       # Leave false unless migrating to InfiniBand too
+    enabled: false # Keep false for DMA-BUF; true enables legacy nvidia-peermem
 fabricManager:
-  enabled: false         # Set true for SXM GPUs
+  enabled: false # Set true for SXM GPUs
 ```
 
 Watch the rollout until every pod is `Running` and validators succeed (`nvidia-cuda-validator` = `Completed`, `nvidia-operator-validator` = `Running`):
@@ -153,8 +167,7 @@ Watch the rollout until every pod is `Running` and validators succeed (`nvidia-c
 kubectl -n gpu-operator get pods -w
 ```
 
-Brief driver crashloops during first bring-up often self-heal — wait for the validators before rolling back.
-The Operator's driver daemonset only schedules on nodes it can manage — cleaned, uncordoned nodes. Uncordon each node after its driver pod is ready (Step 5).
+Brief driver crashloops during first bring-up often self-heal — wait for the validators before rolling back. The Operator's driver DaemonSet can run on a cordoned node; keep each node cordoned until its driver pod and validators are healthy, then uncordon it in Step 5.
 
 ## Step 5 — Uncordon and verify
 
@@ -169,10 +182,24 @@ kubectl get nodes -o custom-columns=\
 NAME:.metadata.name,\
 GPUs:.status.allocatable.nvidia\\.com/gpu
 
-kubectl run gpu-test --rm -it --restart=Never \
-  --image=nvidia/cuda:12.4.0-base-ubuntu22.04 \
-  --limits=nvidia.com/gpu=1 \
-  -- nvidia-smi
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: nvidia-smi
+      image: nvidia/cuda:13.0.3-base-ubuntu24.04
+      command: ["nvidia-smi"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+EOF
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/gpu-test --timeout=5m
+kubectl logs gpu-test
+kubectl delete pod gpu-test
 ```
 
 ## Step 6 — Verify the provider

--- a/src/content/Docs/providers/operations/lease-management/index.md
+++ b/src/content/Docs/providers/operations/lease-management/index.md
@@ -4,319 +4,128 @@ tags: ["Operations", "Leases"]
 weight: 1
 title: "Lease Management"
 linkTitle: "Lease Management"
-description: "Manage active leases, track earnings, and handle lease lifecycle"
+description: "Inspect active leases and perform provider-side lease operations"
 ---
 
-This guide covers lease management operations for Akash providers. Most lease management tasks can be automated using two scripts. The manual commands at the bottom are provided for reference and troubleshooting.
+Use the unified `akt` CLI for on-chain lease operations and `kubectl` for the workloads represented inside the provider cluster. Comparing both views helps identify a lease that is closed on-chain but still has cluster resources, or a live lease whose workload is unhealthy.
 
----
+## Before you start
 
-## Automated Lease Management (Recommended)
-
-The following two scripts automate most lease management tasks. Set them up once and let them run automatically.
-
-### 1. Dangling Deployments Cleanup
-
-Occasionally, leases may be closed on-chain but remain active in Kubernetes (or vice versa), creating "dangling deployments." These orphaned deployments consume resources without generating revenue.
-
-**This script automatically identifies and removes dangling deployments.**
-
-#### Download and Run
+Install [`akt`](/docs/developers/deployment/akt/installation) and select a mainnet keyring context containing the provider key. Confirm the active identity before a transaction:
 
 ```bash
-cd ~
-wget https://gist.githubusercontent.com/Zblocker64/6da5f4833289270450260d360922cb11/raw/6035d31758143ee0b8edcfcf1b295225a2691bb7/cleanup_provider.sh
-chmod +x cleanup_provider.sh
-./cleanup_provider.sh
+akt context show
+akt context keys show <provider-key> --address
 ```
 
-#### What the Script Does
+The address must match the provider owner recorded in `provider.yaml`.
 
-- Compares on-chain lease state with Kubernetes manifests
-- Identifies discrepancies between chain and cluster
-- Automatically cleans up dangling resources
-- Reports deployments that were removed
+## List active provider leases
 
-**Run this script regularly** (daily or weekly) to keep your provider clean.
-
-### 2. Close Leases by Container Image
-
-Block specific container images by automatically closing leases that use them.
-
-**This script automatically monitors and closes deployments using unwanted images.**
-
-#### Create the Script
-
-Create `/usr/local/bin/akash-kill-lease.sh`:
+Query active leases by provider address:
 
 ```bash
-#!/bin/bash
-
-# Uncomment and set IMAGES to activate
-# IMAGES="packetstream/psclient"
-
-# Multiple images separated by "|"
-# IMAGES="packetstream/psclient|traffmonetizer/cli"
-
-# Exit if no images specified
-test -z $IMAGES && exit 0
-
-kubectl -n lease get manifests -o json | \
-  jq --arg md_lid "akash.network/lease.id" -r '.items[] | [(.metadata.labels | .[$md_lid+".owner"], .[$md_lid+".dseq"], .[$md_lid+".gseq"], .[$md_lid+".oseq"]), (.spec.group | .services[].image)] | @tsv' | \
-  grep -Ei "$IMAGES" | \
-  while read owner dseq gseq oseq image; do
-    kubectl -n akash-services exec -i $(kubectl -n akash-services get pods -l app=akash-provider -o name) -- \
-      env AKASH_OWNER=$owner AKASH_DSEQ=$dseq AKASH_GSEQ=$gseq AKASH_OSEQ=$oseq \
-      provider-services tx market bid close
-  done
-```
-
-#### Make Executable
-
-```bash
-chmod +x /usr/local/bin/akash-kill-lease.sh
-```
-
-#### Create Cron Job (Automate It)
-
-Create `/etc/cron.d/akash-kill-lease`:
-
-```
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-SHELL=/bin/bash
-
-*/5 * * * * root /usr/local/bin/akash-kill-lease.sh
-```
-
-This cron job runs every 5 minutes to automatically close leases with unwanted images.
-
-**Note:** The image name is only known **after** the client sends the manifest (post-bid acceptance), so the provider will have already bid on the deployment.
-
----
-
-## Manual Operations
-
-The commands below are for manual troubleshooting and one-off operations. **Most providers won't need these** - the automated scripts above handle lease management automatically.
-
-### List Provider Active Leases
-
-View all active leases on your provider to monitor current deployments.
-
-### Command Template
-
-```bash
-provider-services query market lease list \
-  --provider <provider-address> \
-  --gseq 0 \
-  --oseq 0 \
+akt query market lease \
+  --by provider \
+  <provider-address> \
+  active \
   --page 1 \
-  --limit 500 \
-  --state active
+  --limit 500
 ```
 
-### Example
+`akt` uses positional resource filters. The active context supplies the chain ID, RPC endpoint, and query defaults.
+
+## Compare leases with cluster workloads
+
+List the provider's workload records and their lease labels:
 
 ```bash
-provider-services query market lease list \
-  --provider akash1yvu4hhnvs84v4sv53mzu5ntf7fxf4cfup9s22j \
-  --gseq 0 \
-  --oseq 0 \
+kubectl --namespace lease get manifests --show-labels
+kubectl --namespace lease get providerhosts
+```
+
+Inspect one manifest:
+
+```bash
+kubectl --namespace lease get manifest <manifest-name> --output yaml
+```
+
+The labels identify the owner, deployment sequence (`dseq`), group sequence (`gseq`), order sequence (`oseq`), and provider. Match that tuple to the on-chain lease result.
+
+Deployment routes use Gateway API resources. Confirm them with:
+
+```bash
+kubectl get httproutes --all-namespaces
+```
+
+## Close a provider bid
+
+Closing a bid terminates the provider side of the lease and releases its capacity. Verify the exact lease tuple and reason before signing:
+
+```bash
+akt tx market bid close \
+  --owner <tenant-address> \
+  --dseq <dseq> \
+  --gseq <gseq> \
+  --oseq <oseq> \
+  --from <provider-key> \
+  --reason 10002 \
+  --yes
+```
+
+The provider address is derived from the signing key. Do not pass the tenant's key or address to `--from`.
+
+Provider reason codes are:
+
+|    Code | Meaning                                |
+| ------: | -------------------------------------- |
+| `10000` | Workload or environment instability    |
+| `10001` | Planned decommissioning                |
+| `10002` | Unspecified provider reason            |
+| `10003` | Tenant did not send a manifest in time |
+
+If the lease uses a reclamation window, follow the [reclamation procedure](/docs/providers/setup-and-installation/kubespray/reclamation). The chain rejects a close transaction submitted before its reclamation deadline.
+
+## Verify cleanup
+
+After the transaction is committed, confirm that the lease is no longer active and that its cluster resources disappear:
+
+```bash
+akt query market lease \
+  --by provider \
+  <provider-address> \
+  active \
   --page 1 \
-  --limit 500 \
-  --state active
+  --limit 500
+
+kubectl --namespace lease get manifests --show-labels
+kubectl get namespaces
 ```
 
-### Example Output (payment denom uact / ACT)
-
-```yaml
-leases:
-- escrow_payment:
-    account_id:
-      scope: deployment
-      xid: akash19gs08y80wlk5wl4696wz82z2wrmjw5c84cvw28/5903794
-    balance:
-      amount: "0.455120000000000000"
-      denom: uact
-    owner: akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf
-    rate:
-      amount: "24.780240000000000000"
-      denom: uact
-    state: open
-  lease:
-    closed_on: "0"
-    created_at: "5903822"
-    lease_id:
-      dseq: "5903794"
-      gseq: 1
-      oseq: 1
-      owner: akash19gs08y80wlk5wl4696wz82z2wrmjw5c84cvw28
-      provider: akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf
-    price:
-      amount: "24.780240000000000000"
-      denom: uact
-    state: active
-```
-
-Providers are paid in **ACT** (uact); balance and rate above are in ACT.
-
-## List Active Leases from Kubernetes
-
-View active leases from the Kubernetes cluster perspective using the Hostname Operator.
-
-### Command
+If a closed lease remains in Kubernetes, inspect the provider and operator logs before deleting anything manually:
 
 ```bash
-kubectl -n lease get providerhosts
+kubectl --namespace akash-services logs statefulset/akash-provider --tail 200
+kubectl --namespace akash-services get pods
+kubectl --namespace lease get events --sort-by=.metadata.creationTimestamp
 ```
 
-### Example Output
-
-```
-NAME                                                  AGE
-gtu5bo14f99elel76srrbj04do.ingress.example.com      60m
-kbij2mvdlhal5dgc4pc7171cmg.ingress.example.com      18m
-```
-
-## Close a Lease (Provider-Side)
-
-Providers can close bids to terminate deployments and recover provider escrow.
-
-**What happens when you close a lease:**
-- Closes the lease (payment channel) immediately
-- Terminates the workload running on the provider
-- Returns provider escrow to the provider (in ACT)
-- Tenant must close their deployment separately to recover their escrow (default deposit in ACT)
-
-### Command Template
+Restart the provider only after identifying a reconciliation problem:
 
 ```bash
-provider-services tx market bid close \
-  --node $AKASH_NODE \
-  --chain-id $AKASH_CHAIN_ID \
-  --owner <TENANT-ADDRESS> \
-  --dseq <DSEQ> \
-  --gseq 1 \
-  --oseq 1 \
-  --from <PROVIDER-ADDRESS> \
-  --keyring-backend $AKASH_KEYRING_BACKEND \
-  -y \
-  --gas-prices="0.025uakt" \
-  --gas="auto" \
-  --gas-adjustment=1.15
+kubectl --namespace akash-services rollout restart statefulset/akash-provider
+kubectl --namespace akash-services rollout status statefulset/akash-provider
 ```
 
-### Example
+## Automation safety
 
-```bash
-provider-services tx market bid close \
-  --node $AKASH_NODE \
-  --chain-id akashnet-2 \
-  --owner akash1n44zc8l6gfm0hpydldndpg8n05xjjwmuahc6nn \
-  --dseq 5905802 \
-  --gseq 1 \
-  --oseq 1 \
-  --from akash1yvu4hhnvs84v4sv53mzu5ntf7fxf4cfup9s22j \
-  --keyring-backend os \
-  -y \
-  --gas-prices="0.025uakt" \
-  --gas="auto" \
-  --gas-adjustment=1.15
-```
+Do not automate lease closure by executing the legacy `provider-services` binary inside the provider pod. The `akt` binary, context, and signing key are not supplied by that pod, and interactive keyrings are unsuitable for unattended cron jobs.
 
-## Retrieve Active Manifest List
+An automated policy needs a dedicated, least-privilege keyring context, a non-interactive secret source, exact allow or deny rules, transaction auditing, retry protection, and alerting. Test the policy with `akt`'s `--dry-run` option before enabling signed transactions. Keep private keys outside scripts, container images, and Git.
 
-List all active manifests (deployments) running on your provider.
+## Related resources
 
-### Command
-
-```bash
-kubectl -n lease get manifests --show-labels
-```
-
-### Example Output
-
-```
-NAME                                            AGE   LABELS
-h644k9qp92e0qeakjsjkk8f3piivkuhgc6baon9tccuqo   26h   akash.network/lease.id.dseq=5950031,akash.network/lease.id.gseq=1,akash.network/lease.id.oseq=1,akash.network/lease.id.owner=akash15745vczur53teyxl4k05u250tfvp0lvdcfqx27,akash.network/lease.id.provider=akash1xmz9es9ay9ln9x2m3q8dlu0alxf0ltce7ykjfx
-```
-
-## Retrieve Manifest Details
-
-Get detailed information about a specific deployment's manifest.
-
-### Command Template
-
-```bash
-kubectl -n lease get manifest <namespace> -o yaml
-```
-
-### Example
-
-```bash
-kubectl -n lease get manifest moc58fca3ccllfrqe49jipp802knon0cslo332qge55qk -o yaml
-```
-
-## Deployment Routing Verification
-
-Verify that deployment hostnames are routed correctly. With the Gateway API stack, the hostname operator creates **HTTPRoute** resources for each deployment.
-
-### Command (Gateway API)
-
-```bash
-kubectl get httproute -A
-```
-
-### Example Output (Gateway API)
-
-```
-NAMESPACE                                       NAME                                      HOSTNAMES                                          AGE
-moc58fca3ccllfrqe49jipp802knon0cslo332qge55qk   5n0vp4dmbtced00smdvb84ftu4.ingress.example.com   5n0vp4dmbtced00smdvb84ftu4.ingress.example.com   70s
-```
-
-## Terminate Workload from Provider (CLI Method)
-
-Alternative method to close a bid using `kubectl exec`.
-
-### Step 1: Find the Deployment
-
-```bash
-kubectl -n lease get manifest --show-labels --sort-by='.metadata.creationTimestamp'
-```
-
-### Step 2: Close the Bid
-
-```bash
-kubectl -n akash-services exec -i $(kubectl -n akash-services get pods -l app=akash-provider --output jsonpath='{.items[0].metadata.name}') -- \
-  bash -c "provider-services tx market bid close \
-    --owner <owner-address> \
-    --dseq <dseq> \
-    --oseq 1 \
-    --gseq 1 \
-    -y"
-```
-
-### Step 3: Verify Provider Health
-
-Watch provider logs to ensure bidding continues normally:
-
-```bash
-kubectl -n akash-services logs -l app=akash-provider --tail=100 -f | \
-  grep -Ev "running check|check result|cluster resources|service available replicas below target"
-```
-
-### Restart Provider if Needed
-
-If account sequence mismatches occur, restart the provider:
-
-```bash
-kubectl -n akash-services delete pods -l app=akash-provider
-```
-
----
-
-## Related Resources
-
-- [Provider Status & Monitoring](/docs/providers/operations/monitoring)
-- [Provider Logs](/docs/providers/operations/monitoring#provider-logs)
+- [`akt` queries and transactions](/docs/developers/deployment/akt/queries-and-transactions)
+- [`akt` contexts and key management](/docs/developers/deployment/akt/configuration)
+- [Provider Status and Monitoring](/docs/providers/operations/monitoring)
 - [Provider Verification](/docs/providers/operations/provider-verification)
-

--- a/src/content/Docs/providers/operations/monitoring/index.md
+++ b/src/content/Docs/providers/operations/monitoring/index.md
@@ -67,13 +67,13 @@ Get comprehensive provider status including active leases, resource utilization,
 ### Command Template
 
 ```bash
-provider-services status <provider-address>
+akt provider status <provider-address>
 ```
 
 ### Example
 
 ```bash
-provider-services status akash1wxr49evm8hddnx9ujsdtd86gk46s7ejnccqfmy
+akt provider status akash1wxr49evm8hddnx9ujsdtd86gk46s7ejnccqfmy
 ```
 
 ### Example Output
@@ -132,212 +132,130 @@ provider-services status akash1wxr49evm8hddnx9ujsdtd86gk46s7ejnccqfmy
 
 ## GPU Provider Troubleshooting
 
-When GPU deployments fail or GPUs aren't detected, use these steps to diagnose issues.
+The Provider Playbook installs NVIDIA GPU Operator `v26.7.0`. The Operator manages the NVIDIA driver, Container Toolkit, device plugin, validators, and Fabric Manager as Kubernetes workloads. Do not install or upgrade those packages directly on the host; host-managed NVIDIA packages conflict with the Operator-managed stack.
 
-**Scope:** Conduct these checks on **each Kubernetes worker node** hosting GPU resources unless specified otherwise.
+Run the Kubernetes checks below from a control-plane node or another machine with cluster-admin access to the cluster.
 
-### Basic GPU Verifications
-
-#### Install Testing Tools
+### Check the GPU Operator
 
 ```bash
-apt update && apt -y install python3-venv
-python3 -m venv /venv
-source /venv/bin/activate
-pip install torch numpy
+helm status gpu-operator --namespace gpu-operator
+kubectl get clusterpolicy cluster-policy
+kubectl --namespace gpu-operator get deployments,daemonsets
+kubectl --namespace gpu-operator get pods --output wide
 ```
 
-#### Verify GPU Detection
+A healthy installation has:
+
+- A ready `cluster-policy` and a running GPU Operator controller
+- Driver, Container Toolkit, device plugin, and operator validator pods on each GPU node
+- `nvidia-cuda-validator` pods in `Completed` state
+- `nvidia-operator-validator` pods in `Running` state
+
+Driver pods can restart briefly while the Operator reconciles a node. Use the validators and ClusterPolicy state to decide whether the installation is ready.
+
+### Check Allocatable GPUs
+
+Confirm Kubernetes has discovered the expected number of GPUs on every node:
 
 ```bash
-nvidia-smi -L
+kubectl get nodes \
+  --output='custom-columns=NAME:.metadata.name,GPUS:.status.allocatable.nvidia\.com/gpu'
 ```
 
-**Expected Output:**
-
-```
-GPU 0: Tesla T4 (UUID: GPU-faa48437-7587-4bc1-c772-8bd099dba462)
-```
-
-If no GPUs are listed, check:
-- Driver installation
-- Hardware connection
-- BIOS/UEFI settings
-
-#### Check CUDA Version
+If a GPU node reports an empty value or `0`, inspect the Operator pods assigned to that node:
 
 ```bash
-python3 -c "import torch;print(torch.version.cuda)"
+kubectl --namespace gpu-operator get pods --output wide
 ```
 
-**Expected Output:** `12.7` (or your installed CUDA version)
-
-#### Verify CUDA GPU Support
+Then connect to the affected node and confirm that its PCI bus exposes NVIDIA hardware:
 
 ```bash
-python3 -c "import torch; print(torch.cuda.is_available())"
+lspci -nn | grep -i nvidia
 ```
 
-**Expected Output:** `True`
+### Run an End-to-End CUDA Test
 
-If `False`, see the NVIDIA Fabric Manager section below.
+Create a disposable pod that requests one GPU and runs `nvidia-smi` inside the Operator-managed CUDA environment:
 
-### Check Kernel Logs for GPU Errors
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: cuda
+      image: nvidia/cuda:13.0.3-base-ubuntu24.04
+      command: ["nvidia-smi"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+EOF
 
-Examine kernel logs for driver issues, version mismatches, or hardware errors:
+kubectl wait pod/gpu-test \
+  --for=jsonpath='{.status.phase}'=Succeeded \
+  --timeout=5m
+kubectl logs gpu-test
+kubectl delete pod gpu-test
+```
+
+If the pod does not succeed, leave it in place while you inspect `kubectl describe pod gpu-test` and `kubectl logs gpu-test`. Delete it after collecting the failure details.
+
+### Inspect a Failing Operator Component
+
+Use the failing pod name from the Operator status output:
+
+```bash
+kubectl --namespace gpu-operator describe pod <pod-name>
+kubectl --namespace gpu-operator logs <pod-name> --all-containers
+```
+
+The pod prefix identifies the failing layer:
+
+- `nvidia-driver-daemonset`: NVIDIA driver or kernel compatibility
+- `nvidia-container-toolkit-daemonset`: container runtime integration
+- `nvidia-device-plugin-daemonset`: GPU resource discovery and advertisement
+- `nvidia-cuda-validator`: CUDA initialization
+- `nvidia-operator-validator`: overall Operator validation
+
+For driver or kernel failures, connect to the affected node and inspect its kernel log:
 
 ```bash
 dmesg -T | grep -Ei 'nvidia|nvml|cuda|mismatch'
 ```
 
-#### Healthy Output Example
+If the node has host-installed NVIDIA driver, Container Toolkit, or Fabric Manager packages, remove that conflicting installation before redeploying with the Provider Playbook.
 
-```
-[Thu Sep 28 19:29:02 2023] nvidia: loading out-of-tree module taints kernel.
-[Thu Sep 28 19:29:02 2023] NVRM: loading NVIDIA UNIX x86_64 Kernel Module  580.13.04
-[Thu Sep 28 19:29:02 2023] nvidia-modeset: Loading NVIDIA Kernel Mode Setting Driver for UNIX platforms  580.13.04
-[Thu Sep 28 19:29:04 2023] [drm] Initialized nvidia-drm 0.0.0 20160202 for 0000:00:04.0 on minor 0
-[Thu Sep 28 19:29:05 2023] nvidia-uvm: Loaded the UVM driver, major device number 235.
-```
+### Check Operator-Managed Fabric Manager
 
-#### Problem Indicators
+Fabric Manager is normally needed for SXM/NVSwitch systems and not for PCIe-only GPU systems. The setup wizard detects supported SXM GPU models and configures the GPU Operator accordingly.
 
-- `mismatch` errors → Driver/kernel version conflict
-- `failed to initialize` → Hardware or configuration issue
-- Missing `nvidia-uvm` → Incomplete driver installation
-
-### Verify NVIDIA Device Plugin
-
-The NVIDIA Device Plugin DaemonSet must be running on all GPU nodes for Kubernetes to schedule GPU workloads.
-
-#### Check Plugin Status
+Check the configured state and any Fabric Manager workloads:
 
 ```bash
-kubectl get pods -n nvidia-device-plugin -l app.kubernetes.io/name=nvidia-device-plugin
+kubectl get clusterpolicy cluster-policy \
+  --output=jsonpath='{.spec.fabricManager.enabled}{"\n"}'
+kubectl --namespace gpu-operator get daemonsets,pods --output wide | grep -i fabric
 ```
 
-#### Expected Output
-
-```
-NAME                                         READY   STATUS    RESTARTS   AGE
-nvidia-device-plugin-daemonset-abc123        1/1     Running   0          2d3h
-nvidia-device-plugin-daemonset-def456        1/1     Running   0          2d3h
-```
-
-**Indicators:**
-- `READY` should be `1/1`
-- `STATUS` should be `Running`
-- One pod per GPU-enabled node
-
-#### Troubleshooting Plugin Issues
-
-If pods are not running:
+When Fabric Manager is enabled, an `nvidia-fabricmanager` pod should run on each applicable node. Inspect a failing pod with:
 
 ```bash
-# Check pod events
-kubectl describe pod -n nvidia-device-plugin <pod-name>
-
-# Check DaemonSet status
-kubectl get daemonset -n nvidia-device-plugin
-
-# View plugin logs
-kubectl logs -n nvidia-device-plugin <pod-name>
+kubectl --namespace gpu-operator describe pod <fabric-manager-pod>
+kubectl --namespace gpu-operator logs <fabric-manager-pod> --all-containers
 ```
 
-### NVIDIA Fabric Manager (SXM GPUs)
-
-**When Needed:** NVIDIA Fabric Manager is **required for non-PCIe GPU configurations** such as:
-- SXM form factor GPUs
-- NVLink-connected GPUs
-- Multi-GPU setups with direct GPU-to-GPU communication
-
-#### Common Error
-
-If `torch.cuda.is_available()` returns:
-
-```
-Error 802: system not yet initialized (Triggered internally at ../c10/cuda/CUDAFunctions.cpp:109.)
-```
-
-Install Fabric Manager to resolve this issue.
-
-#### Install Fabric Manager
-
-Replace `580` with your NVIDIA driver version:
-
-```bash
-apt-get install nvidia-fabricmanager-580
-systemctl start nvidia-fabricmanager
-systemctl enable nvidia-fabricmanager
-```
-
-**Initialization Time:** Wait 2-3 minutes after starting the service before testing GPU availability.
-
-#### Verify Fabric Manager Status
-
-```bash
-systemctl status nvidia-fabricmanager
-```
-
-**Expected Output:**
-
-```
-● nvidia-fabricmanager.service - NVIDIA Fabric Manager Daemon
-     Loaded: loaded
-     Active: active (running) since ...
-```
-
-### Fabric Manager Version Mismatch
-
-Ubuntu repositories may not provide a Fabric Manager version matching your driver, causing startup failures.
-
-#### Symptom
-
-```bash
-systemctl status nvidia-fabricmanager
-```
-
-Shows:
-
-```
-nv-fabricmanager[104230]: fabric manager NVIDIA GPU driver interface version 580.127.05 doesn't match with driver version 580.120
-systemd[1]: nvidia-fabricmanager.service: Control process exited, code=exited, status=1/FAILURE
-```
-
-#### Fix: Use Official NVIDIA Repository
-
-**Prerequisites:**
-- Ubuntu 24.04 LTS
-- Root access
-
-Add the official NVIDIA CUDA repository:
-
-```bash
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/3bf863cc.pub
-apt-key add 3bf863cc.pub
-
-echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/ /" > /etc/apt/sources.list.d/nvidia-official-repo.list
-
-apt update
-apt dist-upgrade
-apt autoremove
-```
-
-**Tip:** Running `apt dist-upgrade` with the official NVIDIA repo upgrades all NVIDIA packages (driver, fabric manager, CUDA tools) in sync, preventing version mismatches.
-
-#### Verify Package Versions
-
-```bash
-dpkg -l | grep nvidia
-```
-
-Remove any unexpected versions and **reboot the node** to apply changes.
+For a PCIe-only system, `false` and no Fabric Manager pod are expected. Do not install `nvidia-fabricmanager` with `apt`; correct the GPU Operator configuration and let the Operator reconcile the node.
 
 ### Additional GPU Resources
 
-- [NVIDIA Developer Forum - Error 802](https://forums.developer.nvidia.com/t/error-802-system-not-yet-initialized-cuda-11-3/234955)
-- [NVIDIA Driver Documentation](https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/)
-- [Kubernetes Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+- [NVIDIA GPU Operator Troubleshooting](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/troubleshooting.html)
+- [NVIDIA GPU Operator Platform Support](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html)
+- [GPU Support Setup](/docs/providers/setup-and-installation/kubespray/gpu-support)
 
 ---
 
@@ -347,4 +265,3 @@ Remove any unexpected versions and **reboot the node** to apply changes.
 - [GPU Support Setup](/docs/providers/setup-and-installation/kubespray/gpu-support)
 - [Lease Management](/docs/providers/operations/lease-management)
 - [Updates & Maintenance](/docs/providers/operations/updates-maintenance)
-

--- a/src/content/Docs/providers/operations/provider-attributes/index.md
+++ b/src/content/Docs/providers/operations/provider-attributes/index.md
@@ -39,6 +39,7 @@ After updating attributes, restart your provider:
 cd /root/provider
 helm upgrade akash-provider akash/provider \
   -n akash-services \
+  --version 19.0.2 \
   -f provider.yaml \
   --set bidpricescript="$(cat price_script.sh | openssl base64 -A)"
 ```
@@ -260,12 +261,12 @@ See [GPU Capabilities](#gpu-capabilities) below for RAM and interface sub-keys.
 
 ### cuda
 
-- **Value**: CUDA version string (for example `12.7`, `13.0`)
+- **Value**: CUDA version string (the current Provider Playbook advertises `13.0`)
 - **Purpose**: Advertise the CUDA version available on GPU nodes
 
 ```yaml
 - key: cuda
-  value: "12.7"
+  value: "13.0"
 ```
 
 ### capabilities/gpu-interconnect
@@ -406,7 +407,7 @@ Advertise support for advanced features.
   value: "true"
 ```
 
-> **Important:** You can only advertise **one persistent storage class** per provider. Match Rook-Ceph: **`beta3` (NVMe) is the default** in the Persistent Storage guide; use `beta2` (SSD) or `beta1` (HDD) only if you configured that instead.
+> **Important:** You can only advertise **one persistent storage class** per provider. Match the class to the storage media you actually configured: `beta3` for NVMe, `beta2` for SSD, or `beta1` for HDD. The Persistent Storage guide uses `beta3` only because its worked example uses NVMe disks.
 
 ### feat-shm
 
@@ -476,6 +477,7 @@ Advertise support for advanced features.
 ```
 
 Both `capabilities/ip-lease` and `feat-endpoint-ip` should be set when offering IP leases.
+
 ### feat-endpoint-custom-domain
 
 - **Values**: `true`, `false`
@@ -494,9 +496,9 @@ Both `capabilities/ip-lease` and `feat-endpoint-ip` should be set when offering 
 - **Purpose**: Advertise Trusted Execution Environment (Confidential Compute) support
 - **Required**: Only if your provider supports TEE workloads
 
-| Value | Description |
-|-------|-------------|
-| `cpu` | CPU-only confidential VMs (AMD SEV-SNP or Intel TDX) |
+| Value     | Description                                                                        |
+| --------- | ---------------------------------------------------------------------------------- |
+| `cpu`     | CPU-only confidential VMs (AMD SEV-SNP or Intel TDX)                               |
 | `cpu-gpu` | Confidential VMs with NVIDIA GPU Confidential Computing (AMD SEV-SNP or Intel TDX) |
 
 The actual hardware platform (`snp` or `tdx`) is detected by the provider from Kubernetes node labels at runtime and is not advertised as a provider attribute.
@@ -593,11 +595,11 @@ If your GPU isn't in the [provider-configs database](https://github.com/akash-ne
 
 Advertise these attributes only after you have completed [Part 2 — InfiniBand / RDMA](/docs/providers/setup-and-installation/kubespray/gpu-support#part-2--infiniband--rdma-optional) — and, for RoCE, [Part 3 — RoCE Rail Networks](/docs/providers/setup-and-installation/kubespray/gpu-support#part-3--roce-rail-networks-optional) — and verified RDMA on the cluster. Tenants request interconnect in the SDL with `gpu.attributes.interconnect` and match on these placement attributes.
 
-| On-chain key | When to set |
-| ------------ | ----------- |
-| `capabilities/gpu-interconnect` | Always, if you offer multi-node RDMA |
-| `capabilities/gpu-interconnect/fabric/infiniband` | If nodes use InfiniBand HCAs |
-| `capabilities/gpu-interconnect/fabric/roce` | If nodes use RoCE (requires [Part 3 rail networks](/docs/providers/setup-and-installation/kubespray/gpu-support#part-3--roce-rail-networks-optional) and provider ≥ 0.16.2) |
+| On-chain key                                      | When to set                                                                                                                                                                 |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `capabilities/gpu-interconnect`                   | Always, if you offer multi-node RDMA                                                                                                                                        |
+| `capabilities/gpu-interconnect/fabric/infiniband` | If nodes use InfiniBand HCAs                                                                                                                                                |
+| `capabilities/gpu-interconnect/fabric/roce`       | If nodes use RoCE (requires [Part 3 rail networks](/docs/providers/setup-and-installation/kubespray/gpu-support#part-3--roce-rail-networks-optional) and provider ≥ 0.16.2) |
 
 Advertise every fabric you actually support. Omit all interconnect keys if you have no InfiniBand/RoCE hardware. Do **not** advertise `fabric/roce` without the rail networks in place — tenant workloads would receive RDMA devices but be unable to reach the fabric.
 
@@ -698,7 +700,7 @@ attributes:
   - key: feat-endpoint-custom-domain
     value: true
 
-  # Persistent Storage (required if you have Rook-Ceph; beta3 = NVMe default)
+  # Persistent Storage (required if you have Rook-Ceph; beta3 = NVMe)
   - key: capabilities/storage/1/class
     value: beta3
   - key: capabilities/storage/1/persistent
@@ -720,7 +722,7 @@ attributes:
   - key: capabilities/gpu/vendor/nvidia/model/rtx4090/ram/24Gi/interface/pcie
     value: "true"
   - key: cuda
-    value: "12.7"
+    value: "13.0"
 
   # GPU Interconnect (only if you completed InfiniBand / RDMA setup)
   # - key: capabilities/gpu-interconnect
@@ -742,7 +744,7 @@ attributes:
 After updating your provider, verify attributes are registered:
 
 ```bash
-provider-services query provider get <your-provider-address>
+akt query provider <your-provider-address>
 ```
 
 Look for your attributes in the `attributes` section of the output.

--- a/src/content/Docs/providers/operations/provider-audit/index.md
+++ b/src/content/Docs/providers/operations/provider-audit/index.md
@@ -69,41 +69,41 @@ Everything else in the checklist below is **required** — contact info, locatio
 Verify your attributes on-chain:
 
 ```bash
-provider-services query provider get <your-provider-address> -o text
+akt query provider <your-provider-address> --output yaml
 ```
 
 Canonical key names and allowed values: [provider-attributes.json](https://github.com/akash-network/console/blob/main/config/provider-attributes.json).
 
 ### Always required (every provider)
 
-| On-chain key | Notes |
-| ------------ | ----- |
-| `host` | Must be `akash` |
-| `tier` | Must be `community` for community audit |
-| `organization` | Operator name |
-| `email` | Working contact email |
-| `discord-username` | Your Discord username (must match someone in Akash Discord with Provider role) |
-| `website` | Organization website URL |
-| `status-page` | Public status page URL (use your website if you have no separate status page) |
-| `location-region` | [UN geoscheme](https://en.wikipedia.org/wiki/United_Nations_geoscheme) value — **not** the legacy `region` key |
-| `country` | ISO 3166 Alpha-2 code |
-| `city` | Three-letter city code |
-| `timezone` | UTC offset (e.g. `utc-8`) |
-| `location-type` | `datacenter`, `colo`, `home`, `office`, or `mix` |
-| `hosting-provider` | Facility or cloud name (e.g. `hetzner`, `equinix`) |
-| `capabilities/cpu` | `intel`, `amd`, or `arm` |
-| `capabilities/cpu/arch` | e.g. `x86-64` |
-| `capabilities/memory` | e.g. `ddr4`, `ddr5`, `ddr5ecc` |
-| `network-provider` | ISP name |
-| `network-speed-up` | Upload Mbps — **minimum 500** for audit |
-| `network-speed-down` | Download Mbps — **minimum 500** for audit |
-| `feat-shm` | Must be `true` |
-| `capabilities/storage/2/class` | Must be `ram` |
-| `capabilities/storage/2/persistent` | Must be `"false"` |
-| `capabilities/ip-lease` | `"true"` or `"false"` — declare explicitly |
-| `feat-endpoint-ip` | `"true"` or `"false"` — declare explicitly |
-| `feat-endpoint-custom-domain` | `true` or `false` — declare explicitly |
-| `feat-persistent-storage` | `true` or `false` — declare explicitly |
+| On-chain key                        | Notes                                                                                                          |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `host`                              | Must be `akash`                                                                                                |
+| `tier`                              | Must be `community` for community audit                                                                        |
+| `organization`                      | Operator name                                                                                                  |
+| `email`                             | Working contact email                                                                                          |
+| `discord-username`                  | Your Discord username (must match someone in Akash Discord with Provider role)                                 |
+| `website`                           | Organization website URL                                                                                       |
+| `status-page`                       | Public status page URL (use your website if you have no separate status page)                                  |
+| `location-region`                   | [UN geoscheme](https://en.wikipedia.org/wiki/United_Nations_geoscheme) value — **not** the legacy `region` key |
+| `country`                           | ISO 3166 Alpha-2 code                                                                                          |
+| `city`                              | Three-letter city code                                                                                         |
+| `timezone`                          | UTC offset (e.g. `utc-8`)                                                                                      |
+| `location-type`                     | `datacenter`, `colo`, `home`, `office`, or `mix`                                                               |
+| `hosting-provider`                  | Facility or cloud name (e.g. `hetzner`, `equinix`)                                                             |
+| `capabilities/cpu`                  | `intel`, `amd`, or `arm`                                                                                       |
+| `capabilities/cpu/arch`             | e.g. `x86-64`                                                                                                  |
+| `capabilities/memory`               | e.g. `ddr4`, `ddr5`, `ddr5ecc`                                                                                 |
+| `network-provider`                  | ISP name                                                                                                       |
+| `network-speed-up`                  | Upload Mbps — **minimum 500** for audit                                                                        |
+| `network-speed-down`                | Download Mbps — **minimum 500** for audit                                                                      |
+| `feat-shm`                          | Must be `true`                                                                                                 |
+| `capabilities/storage/2/class`      | Must be `ram`                                                                                                  |
+| `capabilities/storage/2/persistent` | Must be `"false"`                                                                                              |
+| `capabilities/ip-lease`             | `"true"` or `"false"` — declare explicitly                                                                     |
+| `feat-endpoint-ip`                  | `"true"` or `"false"` — declare explicitly                                                                     |
+| `feat-endpoint-custom-domain`       | `true` or `false` — declare explicitly                                                                         |
+| `feat-persistent-storage`           | `true` or `false` — declare explicitly                                                                         |
 
 **Discord example:**
 
@@ -118,10 +118,10 @@ Use the username reviewers can find in the Akash Discord server (without `@`).
 
 Set `feat-persistent-storage` to `true` and include **one** storage class (HDD, SSD, or NVMe):
 
-| On-chain key | Value |
-| ------------ | ----- |
-| `capabilities/storage/1/class` | `beta1`, `beta2`, or `beta3` |
-| `capabilities/storage/1/persistent` | `"true"` |
+| On-chain key                        | Value                        |
+| ----------------------------------- | ---------------------------- |
+| `capabilities/storage/1/class`      | `beta1`, `beta2`, or `beta3` |
+| `capabilities/storage/1/persistent` | `"true"`                     |
 
 If you **do not** offer persistent storage, set `feat-persistent-storage` to `false` and omit the `capabilities/storage/1/*` keys.
 
@@ -129,14 +129,14 @@ If you **do not** offer persistent storage, set `feat-persistent-storage` to `fa
 
 For each GPU model you offer, include the vendor, model, RAM, and interface keys from [provider-configs](https://github.com/akash-network/provider-configs):
 
-| On-chain key | Notes |
-| ------------ | ----- |
-| `capabilities/gpu` | e.g. `nvidia` |
-| `cuda` | CUDA version on GPU nodes (e.g. `12.7`) |
-| `capabilities/gpu/vendor/<vendor>/model/<model>` | Base model key |
-| `.../ram/<size>` | VRAM for that model |
-| `.../interface/<iface>` | e.g. `pcie`, `sxm` |
-| `.../interface/<iface>/ram/<size>` | Combined interface + RAM key |
+| On-chain key                                     | Notes                                                                       |
+| ------------------------------------------------ | --------------------------------------------------------------------------- |
+| `capabilities/gpu`                               | e.g. `nvidia`                                                               |
+| `cuda`                                           | CUDA version on GPU nodes (the current Provider Playbook advertises `13.0`) |
+| `capabilities/gpu/vendor/<vendor>/model/<model>` | Base model key                                                              |
+| `.../ram/<size>`                                 | VRAM for that model                                                         |
+| `.../interface/<iface>`                          | e.g. `pcie`, `sxm`                                                          |
+| `.../ram/<size>/interface/<iface>`               | Combined RAM + interface key                                                |
 
 See [Provider Attributes — GPU Capabilities](/docs/providers/operations/provider-attributes/#gpu-capabilities) for examples.
 
@@ -146,11 +146,11 @@ If you **do not** run GPUs, omit all `capabilities/gpu/*` keys and `cuda`.
 
 If you advertise multi-node RDMA, include:
 
-| On-chain key | Notes |
-| ------------ | ----- |
-| `capabilities/gpu-interconnect` | `"true"` |
+| On-chain key                                      | Notes                   |
+| ------------------------------------------------- | ----------------------- |
+| `capabilities/gpu-interconnect`                   | `"true"`                |
 | `capabilities/gpu-interconnect/fabric/infiniband` | If you offer InfiniBand |
-| `capabilities/gpu-interconnect/fabric/roce` | If you offer RoCE |
+| `capabilities/gpu-interconnect/fabric/roce`       | If you offer RoCE       |
 
 See [Provider Attributes — GPU Interconnect](/docs/providers/operations/provider-attributes/#gpu-interconnect-infiniband--roce). Omit these keys if you have no InfiniBand/RoCE fabric.
 
@@ -171,7 +171,7 @@ Deploy the audit workload from a **tenant wallet that is not your provider walle
 - **Provider wallet** — the `akash1…` address registered as your provider (used in `provider.yaml` / on-chain provider record)
 - **Tenant wallet** — a different wallet you use only to create the deployment, accept your provider's bid, and pay escrow
 
-Fund the tenant wallet with **AKT** (gas) and **ACT** (deployment escrow). See [Deploy with Console Air](/docs/developers/deployment/console-air) or the [CLI installation guide](/docs/developers/deployment/cli/installation-guide).
+Fund the tenant wallet with **AKT** (gas) and **ACT** (deployment escrow). See [Deploy with Console Air](/docs/developers/deployment/console-air) or the [`akt` deployment guide](/docs/developers/deployment/akt/deployments).
 
 ### Prepare the SDL
 
@@ -196,30 +196,21 @@ Use a CLI key that is **not** your provider key:
 
 ```bash
 # Tenant wallet (must differ from provider owner address)
-export AKASH_KEY_NAME=audit-tenant
-export AKASH_ACCOUNT_ADDRESS=$(provider-services keys show $AKASH_KEY_NAME -a)
-
-# Create deployment from edited SDL
-provider-services tx deployment create standalone-audit.sdl.yaml --from $AKASH_KEY_NAME -y
-
-# Note deployment sequence (dseq) from the transaction output, then list bids
-provider-services query market bid list --owner $AKASH_ACCOUNT_ADDRESS
-
-# Accept YOUR provider's bid only (replace dseq and provider address)
+export AKT_KEY_NAME=audit-tenant
 export PROVIDER_ADDRESS=akash1YOUR_PROVIDER_OWNER
-provider-services tx market lease create \
-  --dseq <dseq> \
-  --provider $PROVIDER_ADDRESS \
-  --from $AKASH_KEY_NAME -y
 
-# Send manifest to your provider
-provider-services send-manifest standalone-audit.sdl.yaml \
-  --dseq <dseq> \
-  --provider $PROVIDER_ADDRESS \
-  --from $AKASH_KEY_NAME
+# Confirm this tenant address differs from PROVIDER_ADDRESS
+akt context keys show "$AKT_KEY_NAME" --address
+
+# Create the deployment, select only this provider, create the lease,
+# and send the manifest as one workflow
+akt deploy standalone-audit.sdl.yaml \
+  --from "$AKT_KEY_NAME" \
+  --bid-select "provider=$PROVIDER_ADDRESS" \
+  --yes
 ```
 
-See [CLI common tasks — Create and Deploy](/docs/developers/deployment/cli/common-tasks#create-and-deploy-an-application) for more detail.
+The active `akt` context must use Akash mainnet and contain the funded tenant key. See [`akt` contexts and key management](/docs/developers/deployment/akt/configuration) and the [`akt` deployment workflow](/docs/developers/deployment/akt/deployments).
 
 The deployment serves a **web UI over HTTPS on port 443**. Share that URL with reviewers when benchmarks finish.
 
@@ -267,7 +258,7 @@ A reviewer will verify attributes, Discord membership, benchmark results, and fo
 - [Provider Attributes](/docs/providers/operations/provider-attributes)
 - [Provider Verification](/docs/providers/operations/provider-verification)
 - [Deploy with Console Air](/docs/developers/deployment/console-air)
-- [CLI common tasks](/docs/developers/deployment/cli/common-tasks)
+- [`akt` deployments](/docs/developers/deployment/akt/deployments)
 - [Community audit guide](https://github.com/akash-network/community/blob/main/audit/README.md)
 - [Provider attributes schema](https://github.com/akash-network/console/blob/main/config/provider-attributes.json)
 

--- a/src/content/Docs/providers/operations/provider-verification/index.md
+++ b/src/content/Docs/providers/operations/provider-verification/index.md
@@ -33,6 +33,7 @@ kubectl -n akash-services logs -l app=akash-provider --tail=100 -f
 ```
 
 **Look for:**
+
 - **`"bidding on order"`** - Provider is creating bids
 - **`"bid complete"`** - Bids are being submitted
 - **`"error"` or `"failed"`** - Investigate errors
@@ -40,10 +41,11 @@ kubectl -n akash-services logs -l app=akash-provider --tail=100 -f
 ### 3. Verify On-Chain Registration
 
 ```bash
-provider-services query provider get <your-provider-address>
+akt query provider <your-provider-address>
 ```
 
 **Verify:**
+
 - Provider address is correct
 - Host URI is accessible
 - Attributes are set correctly
@@ -83,6 +85,7 @@ kubectl -n akash-services logs -l app=akash-provider --tail=100 -f | grep bid
 ```
 
 **If you see no bids:**
+
 - Check your pricing is competitive
 - Verify provider attributes are set
 - Ensure firewall allows inbound connections
@@ -99,6 +102,7 @@ kubectl -n akash-services describe pod akash-provider-0
 ```
 
 **Common causes:**
+
 - Insufficient resources
 - Configuration errors in `provider.yaml`
 - Missing secrets or certificates
@@ -118,7 +122,7 @@ kubectl -n akash-services describe pod akash-provider-0
 
 ```bash
 # Check provider account balance
-provider-services query bank balances <provider-address>
+akt query bank balances <provider-address>
 ```
 
 ### Provider Not Accessible Externally
@@ -132,6 +136,7 @@ grpcurl -insecure <provider-domain>:8444 akash.provider.v1.ProviderRPC.GetStatus
 ```
 
 **If it fails:**
+
 - Verify DNS points to your provider IP
 - Check firewall allows ports 80, 8443, 8444, and 5002
 - Ensure provider domain is in certificate
@@ -147,6 +152,7 @@ kubectl -n lease describe pod <pod-name>
 ```
 
 **Common issues:**
+
 - GPU not available (for GPU deployments)
 - Insufficient resources
 - Image pull errors
@@ -157,7 +163,7 @@ kubectl -n lease describe pod <pod-name>
 After provider installation, verify:
 
 - Provider pod is running (`kubectl -n akash-services get pods`)
-- Provider is registered on-chain (`provider-services query provider get`)
+- Provider is registered on-chain (`akt query provider <provider-address>`)
 - Provider status endpoint is accessible (`curl https://provider:8443/status`)
 - Provider gRPC endpoint is accessible (`grpcurl provider:8444 akash.provider.v1.ProviderRPC.GetStatus`)
 - Provider is bidding on orders (check logs)
@@ -179,4 +185,3 @@ After provider installation, verify:
 ---
 
 **Need Help?** Join [#provider-support on Discord](https://discord.com/channels/747885925232672829/1067866274432274442)
-

--- a/src/content/Docs/providers/setup-and-installation/index.md
+++ b/src/content/Docs/providers/setup-and-installation/index.md
@@ -23,10 +23,11 @@ There are three ways to become an Akash provider, each suited for different use 
  **Skill level:** Intermediate
 
 **Features:**
-- Automated Kubernetes installation
-- Standardized deployment
-- Infrastructure as Code
-- Less room for error
+
+- Build with Kubespray or K3s, or use an existing Kubernetes cluster
+- Guided SSH, network, location, wallet, hardware, GPU, and storage configuration
+- Install only selected components; Kubespray is downloaded only when selected
+- Generate a protected inventory without deploying by using configuration-only mode
 
 **Choose this if:** You want a reliable, repeatable setup process with automation.
 
@@ -41,12 +42,14 @@ There are three ways to become an Akash provider, each suited for different use 
  **Skill level:** Advanced
 
 **Features:**
+
 - Full control over every aspect
 - Maximum customization
 - Production-grade setup with Kubernetes 1.35.4
 - Best for large deployments
 
 **Includes:**
+
 - Kubernetes cluster setup with Kubespray 2.31.0
 - Provider installation with Helm
 - GPU support configuration
@@ -66,6 +69,7 @@ There are three ways to become an Akash provider, each suited for different use 
  **Skill level:** Beginner
 
 **Features:**
+
 - No command line required
 - No Kubernetes knowledge needed
 - Managed Kubernetes setup
@@ -78,33 +82,36 @@ There are three ways to become an Akash provider, each suited for different use 
 
 ## Comparison
 
-| Feature | Provider Playbook | Kubespray | Provider Console |
-|---------|------------------|-----------|------------------|
-| **Ease of Use** |  |  |  |
-| **Setup Time** | ~1 hour | 1-2 hours | 15-30 minutes |
-| **Customization** |  |  |  |
-| **Skill Required** | Medium | High | Low |
-| **Best For** | Most users | Advanced users | Beginners |
-| **CLI Required** | Yes | Yes | No |
-| **Automation** | High | Low | High |
+| Feature            | Provider Playbook | Kubespray      | Provider Console |
+| ------------------ | ----------------- | -------------- | ---------------- |
+| **Ease of Use**    | Guided            | Manual         | Managed          |
+| **Setup Time**     | ~1 hour           | 1-2 hours      | 15-30 minutes    |
+| **Customization**  | High              | Maximum        | Limited          |
+| **Skill Required** | Medium            | High           | Low              |
+| **Best For**       | Most users        | Advanced users | Beginners        |
+| **CLI Required**   | Yes               | Yes            | No               |
+| **Automation**     | High              | Low            | High             |
 
 ---
 
 ## Which Method Should You Choose?
 
 ### Choose Provider Playbook if:
+
 - You want automation but flexibility
 - You have basic Ansible knowledge
 - You want a standardized deployment
 - You're comfortable with command line
 
 ### Choose Kubespray if:
+
 - You need complete control
 - You have Kubernetes expertise
 - You need custom configurations
 - You're building a large provider
 
 ### Choose Provider Console if:
+
 - You're new to providers
 - You want to test quickly
 - You prefer visual interfaces
@@ -114,9 +121,8 @@ There are three ways to become an Akash provider, each suited for different use 
 
 ## Not Sure?
 
-Start with **[Provider Console](/docs/providers/setup-and-installation/provider-console)** to test the waters, then migrate to **Provider Playbook** or **Kubespray** for production deployments.
+Choose the **[Provider Playbook](/docs/providers/setup-and-installation/provider-playbook)** for a guided, self-managed installation. Choose **[Provider Console](/docs/providers/setup-and-installation/provider-console)** when you prefer a managed, browser-based path.
 
 ---
 
 **Ready to choose?** Select your preferred method above!
-

--- a/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/confidential-compute/index.md
@@ -29,12 +29,12 @@ Confidential Compute on Akash uses [Kata Containers](https://katacontainers.io/)
 
 ### Supported Configurations
 
-| TEE Type | Runtime Class | Hardware |
-|----------|---------------|----------|
-| AMD SEV-SNP | `kata-qemu-snp` | AMD with SEV-SNP enabled in BIOS |
-| AMD SEV-SNP + GPU | `kata-qemu-nvidia-gpu-snp` | Above + NVIDIA CC-capable GPU |
-| Intel TDX | `kata-qemu-tdx` | Intel with TDX enabled in BIOS |
-| Intel TDX + GPU | `kata-qemu-nvidia-gpu-tdx` | Above + NVIDIA CC-capable GPU |
+| TEE Type          | Runtime Class              | Hardware                         |
+| ----------------- | -------------------------- | -------------------------------- |
+| AMD SEV-SNP       | `kata-qemu-snp`            | AMD with SEV-SNP enabled in BIOS |
+| AMD SEV-SNP + GPU | `kata-qemu-nvidia-gpu-snp` | Above + NVIDIA CC-capable GPU    |
+| Intel TDX         | `kata-qemu-tdx`            | Intel with TDX enabled in BIOS   |
+| Intel TDX + GPU   | `kata-qemu-nvidia-gpu-tdx` | Above + NVIDIA CC-capable GPU    |
 
 ---
 
@@ -166,6 +166,7 @@ kubectl get node <node-name> -o json | \
 ```
 
 The operator deploys several components:
+
 - **nvidia-vfio-manager** — binds GPUs to the `vfio-pci` driver for passthrough
 - **nvidia-cc-manager** — toggles GPU Confidential Computing mode (default: on)
 - **nvidia-kata-sandbox-device-plugin** — advertises `nvidia.com/pgpu` resources
@@ -200,90 +201,51 @@ kubectl get nodes --show-labels | grep -E "amd.feature|intel.feature"
 
 ---
 
-## STEP 4 — Configure Provider Flags
+## STEP 4 — Configure Provider Values
 
-The Akash provider automatically injects an attestation sidecar into every confidential workload if requested by the user. This sidecar runs inside the TEE and serves hardware-signed attestation reports to tenants. Enable it with the following flags.
+The Akash provider can inject an attestation sidecar into confidential workloads that request it. This sidecar runs inside the TEE and serves hardware-signed attestation reports to tenants. Configure it through the provider Helm values.
 
-### Required Flags
+### Helm values
 
-| Flag | Description | Required |
-|------|-------------|----------|
-| `--attestation-webhook-enabled` | Enables the Kubernetes mutating admission webhook. When active, the provider intercepts pod creation requests for confidential compute workloads and automatically injects the attestation sidecar container before scheduling. | Yes |
-| `--attestation-sidecar-image` | Docker image reference for the attestation sidecar (e.g. `ghcr.io/akash-network/attestation-sidecar:latest`). Required when the webhook is enabled — the provider passes this image to the webhook for injection into every confidential workload. | Yes |
-| `--attestation-webhook-port` | HTTPS port for the webhook server that handles Kubernetes API callbacks. In production, pair this with `--gateway-tls-cert` and `--gateway-tls-key` using a certificate whose SAN includes the provider's K8s service DNS name. Defaults to `9443` and auto-generates a self-signed cert if TLS files are omitted. | No |
+| Value                                 | Description                                                                                              | Required |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------- |
+| `attestation.enabled`                 | Enables the mutating admission webhook that injects the attestation sidecar into confidential workloads. | Yes      |
+| `attestation.sidecarImage.repository` | Container repository for the attestation sidecar.                                                        | Yes      |
+| `attestation.sidecarImage.tag`        | Container tag. When empty, defaults to the provider chart app version.                                   | No       |
+| `attestation.webhookPort`             | HTTPS port used for Kubernetes admission callbacks. Defaults to `9443`.                                  | No       |
 
-### Optional Flags
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--attestation-mock` | Run the sidecar in mock mode with synthetic (fake) attestation reports instead of real TEE hardware evidence. Also switches the webhook registration to a `host.docker.internal` URL for local clusters. **For local development only, never enable in production.** | `false` |
-
-### Example: Helm Values
-
-When deploying the provider with Helm, add these values:
+Add these values to `provider.yaml`:
 
 ```yaml
 # provider.yaml
 attestation:
-  webhookEnabled: true
-  sidecarImage: "ghcr.io/akash-network/attestation-sidecar:latest"
+  enabled: true
   webhookPort: 9443
+  sidecarImage:
+    repository: ghcr.io/akash-network/provider-attestation-sidecar
+    tag: ""
 ```
 
-### Example: CLI Flags
-
-```bash
-provider-services run \
-  --attestation-webhook-enabled \
-  --attestation-sidecar-image "ghcr.io/akash-network/attestation-sidecar:latest" \
-  --attestation-webhook-port 9443
-```
+Leave the tag empty to keep the sidecar aligned with the provider chart app version. Only set an explicit tag when you have verified that it is compatible with the provider version.
 
 ---
 
 ## STEP 5 — Configure Provider Attributes
 
-Tenants discover TEE-capable providers through on-chain attributes. Add both `tee/platform` and `tee/type` to your `provider.yaml`:
+Tenants discover TEE-capable providers through the on-chain `tee/type` attribute. The provider detects the hardware platform from the Kubernetes node labels configured in [Step 3b](#step-3b--label-nodes-for-tee-platform-detection); do not publish a separate `tee/platform` attribute.
 
-- **`tee/platform`** — the hardware TEE platform: `snp` (AMD SEV-SNP) or `tdx` (Intel TDX)
-- **`tee/type`** — the capability offered: `cpu` (CPU-only) or `cpu-gpu` (CPU + GPU Confidential Computing)
-
-### AMD SEV-SNP, CPU only
+### CPU only
 
 ```yaml
 attributes:
-  - key: tee/platform
-    value: snp
   - key: tee/type
     value: cpu
 ```
 
-### AMD SEV-SNP with GPU
+### CPU with confidential GPU
 
 ```yaml
 attributes:
-  - key: tee/platform
-    value: snp
-  - key: tee/type
-    value: cpu-gpu
-```
-
-### Intel TDX, CPU only
-
-```yaml
-attributes:
-  - key: tee/platform
-    value: tdx
-  - key: tee/type
-    value: cpu
-```
-
-### Intel TDX with GPU
-
-```yaml
-attributes:
-  - key: tee/platform
-    value: tdx
   - key: tee/type
     value: cpu-gpu
 ```
@@ -294,6 +256,7 @@ After updating attributes, restart your provider:
 cd /root/provider
 helm upgrade akash-provider akash/provider \
   -n akash-services \
+  --version 19.0.2 \
   -f provider.yaml \
   --set bidpricescript="$(cat price_script.sh | openssl base64 -A)"
 ```
@@ -349,8 +312,11 @@ deployment:
 Deploy and verify:
 
 ```bash
-# Deploy
-provider-services tx deployment create test-cc.yaml --from <your-key>
+# Deploy through the selected provider
+akt deploy test-cc.yaml \
+  --from <your-key> \
+  --bid-select "provider=<provider-address>" \
+  --yes
 
 # After lease is created, check that the pod has the correct runtime class
 kubectl get pods -n <lease-namespace> -o jsonpath='{.items[0].spec.runtimeClassName}'
@@ -364,15 +330,12 @@ kubectl get pods -n <lease-namespace> -o jsonpath='{.items[0].spec.containers[*]
 ### Request an Attestation Quote
 
 ```bash
-provider-services lease-attestation \
-  --dseq <deployment-sequence> \
-  --gseq 1 \
-  --oseq 1 \
-  --provider <provider-address> \
-  --from <your-key>
+AKT_FROM=<your-key> akt provider lease-attestation \
+  <deployment-sequence> \
+  --provider <provider-address>
 ```
 
-A successful response contains a hardware-signed attestation report, confirming the workload is running in a genuine TEE.
+A successful response confirms that the provider returned an attestation payload over an authenticated lease connection and that the request nonce is fresh. `akt` does not currently validate the evidence signature, endorsement chain, or measurement policy, so treat the response as evidence to pass to a TEE verifier rather than proof by itself that the workload is running on genuine TEE hardware.
 
 ---
 
@@ -395,6 +358,7 @@ kubectl describe pod <pod-name> -n <lease-namespace>
 ```
 
 Common causes:
+
 - **RuntimeClass not found**: Verify the RuntimeClass exists with `kubectl get runtimeclass`
 - **No TEE-capable nodes**: Ensure nodes with TEE hardware are labeled and schedulable
 - **Kata not installed**: Check that Kata is properly installed on the target node
@@ -404,7 +368,7 @@ Common causes:
 
 - Verify the webhook is running: `kubectl get mutatingwebhookconfigurations`
 - Check provider logs for webhook errors
-- Ensure `--attestation-webhook-enabled` is set
+- Ensure `attestation.enabled: true` is present in `provider.yaml` and was applied with the Helm upgrade
 
 ### Attestation quote returns error
 

--- a/src/content/Docs/providers/setup-and-installation/kubespray/gpu-support/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/gpu-support/index.md
@@ -20,7 +20,7 @@ It also covers an **optional** InfiniBand / RDMA section ([Part 2](#part-2--infi
 ## Prerequisites
 
 - Kubernetes cluster deployed via [Kubespray](/docs/providers/setup-and-installation/kubespray/kubernetes-setup) (kubeadm + Calico CNI + containerd)
-- **Clean GPU nodes** — no pre-installed NVIDIA drivers, CUDA, or MOFED/OFED on the host. The operators manage all drivers in containers, and a host driver will conflict.
+- **Clean GPU nodes** — no pre-installed NVIDIA driver, CUDA driver package, NVIDIA Container Toolkit, or legacy NVIDIA device-plugin Helm release. For the optional RDMA flow, do not preinstall MOFED/OFED. The operators manage these components, and host-managed copies conflict.
 
 For the optional InfiniBand section, additionally:
 
@@ -34,7 +34,9 @@ For RoCE (Part 3), instead of the InfiniBand fabric items:
 - A dedicated IP subnet per rail (assigned in [Part 3](#part-3--roce-rail-networks-optional))
 - Provider version **0.16.2 or later** (RoCE rail network attachment)
 
-> **Note:** The GPU Operator replaces the older manual host-driver workflow. The hard requirement is that **no NVIDIA driver, CUDA, or MOFED/OFED is installed on the host** — remove any before starting. The GPU Operator manages the container toolkit and containerd runtime for you, so the optional NVIDIA-runtime step in [Kubernetes Setup – Step 7](/docs/providers/setup-and-installation/kubespray/kubernetes-setup#step-7---configure-gpu-support-optional) is not required for this path (it is harmless if already applied).
+> **Note:** The GPU Operator replaces the older manual host-driver workflow. The hard requirement is that **no NVIDIA driver, CUDA driver package, Container Toolkit, or MOFED/OFED is installed on the host** — remove any before starting. The GPU Operator manages the toolkit and CDI integration after Kubernetes is available, as described in [Kubernetes Setup – Step 7](/docs/providers/setup-and-installation/kubespray/kubernetes-setup#step-7---prepare-for-gpu-support-optional).
+
+> **Provider Playbook:** The automated installer reads PCI vendor, device, and class IDs from Linux sysfs on every configured worker and matches them against its checksum-pinned [`provider-configs`](https://github.com/akash-network/provider-configs) database. It derives the canonical model, VRAM, and PCIe/SXM interface automatically; CUDA `13.0` comes from the playbook's central version matrix.
 
 ---
 
@@ -62,18 +64,12 @@ lspci | grep -i nvidia
 
 SXM (HGX/DGX) boards use NVLink/NVSwitch and require the Fabric Manager; PCIe cards do not.
 
-| GPU form factor | Fabric Manager |
-| --- | --- |
-| Any SXM (HGX/DGX) — A100, H100, H200, B200, B300 | Required (`fabricManager.enabled: true`) |
-| Any PCIe — A100-PCIe, L40S, A6000, RTX, etc. | Not needed (`fabricManager.enabled: false`) |
+| GPU form factor                                  | Fabric Manager                              |
+| ------------------------------------------------ | ------------------------------------------- |
+| Any SXM (HGX/DGX) — A100, H100, H200, B200, B300 | Required (`fabricManager.enabled: true`)    |
+| Any PCIe — A100-PCIe, L40S, A6000, RTX, etc.     | Not needed (`fabricManager.enabled: false`) |
 
-Check the form factor:
-
-```bash
-lspci -v | grep -A5 -i nvidia | grep -i "subsystem"
-# "SXM" in the output → needs Fabric Manager
-# No "SXM"           → PCIe, no Fabric Manager needed
-```
+Do not infer the form factor from the absence of the word `SXM` in `lspci`; many systems do not expose that text. Match the numeric PCI ID to the [`provider-configs` GPU database](https://github.com/akash-network/provider-configs) or confirm the board form factor in the server or GPU vendor documentation. The Provider Playbook performs the PCI-ID lookup automatically.
 
 ## Step 2 — Install the GPU Operator
 
@@ -84,22 +80,29 @@ helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
 helm repo update
 ```
 
-Pin the chart to the current stable patch (**`v26.3.3`**). NVIDIA GPU Operator charts use CalVer (`vYY.MM.PP`).
+Pin the chart to **`v26.7.0`**. NVIDIA GPU Operator charts use CalVer (`vYY.MM.PP`).
 
 Create `gpu-operator-values.yaml`:
 
 ```yaml
-operator:
-  defaultRuntime: containerd
+cdi:
+  enabled: true
+  nriPluginEnabled: false # Kubespray; the Provider Playbook enables this for its pinned K3s runtime
+
+toolkit:
+  env: []
+
+hostPaths:
+  kubeletRootDir: "/var/lib/kubelet" # Match a custom kubelet root if configured
 
 driver:
   enabled: true
   rdma:
-    enabled: false       # ← Leave false unless you are doing Part 2 (InfiniBand)
+    enabled: false # ← Keep false for DMA-BUF; true enables legacy nvidia-peermem
     useHostMofed: false
 
 fabricManager:
-  enabled: false         # ← Set true for SXM GPUs (see table above)
+  enabled: false # ← Set true for SXM GPUs (see table above)
 
 migManager:
   enabled: false
@@ -111,23 +114,29 @@ nodeStatusExporter:
   enabled: true
 ```
 
-> **Why `driver.rdma.enabled: false` by default?** With RDMA enabled, the GPU driver pod's init container waits for MOFED (from the Network Operator) and will sit in `Init:0/1` forever if the Network Operator is not installed. Enable it only in [Part 2](#part-2--infiniband--rdma-optional).
+> **Why `driver.rdma.enabled: false` by default?** GPU Operator 26.7 uses the recommended DMA-BUF path for GPUDirect RDMA without this setting. Enabling it opts into the legacy `nvidia-peermem` module and makes the driver pod wait for MOFED.
 
-### First deploy — CRDs
+### Reconcile CRDs before every install or upgrade
 
-`helm upgrade --install` **skips** a chart's `crds/` directory. On a first deploy that causes failures like `no matches for kind "ClusterPolicy"`. Use `helm install` for the initial release (or pre-apply CRDs — see [Troubleshooting](#troubleshooting)).
-
-Deploy (first install):
+Helm does not upgrade CRDs stored in a chart's `crds/` directory. Pull the pinned chart and apply both the GPU Operator and bundled Node Feature Discovery CRDs before the release:
 
 ```bash
-helm install gpu-operator nvidia/gpu-operator \
+rm -rf /tmp/akash-gpu-operator-chart
+helm pull nvidia/gpu-operator \
+  --version v26.7.0 \
+  --untar \
+  --untardir /tmp/akash-gpu-operator-chart
+
+kubectl apply --server-side --force-conflicts \
+  --filename /tmp/akash-gpu-operator-chart/gpu-operator/crds \
+  --filename /tmp/akash-gpu-operator-chart/gpu-operator/charts/node-feature-discovery/crds/nfd-api-crds.yaml
+
+helm upgrade --install gpu-operator nvidia/gpu-operator \
   --namespace gpu-operator \
   --create-namespace \
-  --version v26.3.3 \
+  --version v26.7.0 \
   -f gpu-operator-values.yaml
 ```
-
-Later upgrades can use `helm upgrade` with the same `--version` and values file.
 
 Watch the rollout until every pod is `Running` and validators succeed:
 
@@ -141,6 +150,7 @@ kubectl -n gpu-operator get pods | grep -E 'cuda-validator|operator-validator'
 ```
 
 > **Note:** Driver pods may crashloop briefly during the first bring-up while dependencies start, then self-heal. Wait for the validators above before treating it as a failure.
+
 ## Step 3 — Verify GPUs
 
 Check allocatable GPUs per node:
@@ -159,13 +169,29 @@ node1   8
 node2   8
 ```
 
-Run a GPU test:
+Run a CUDA 13.0 GPU test. Create `gpu-test.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: nvidia-smi
+      image: nvidia/cuda:13.0.3-base-ubuntu24.04
+      command: ["nvidia-smi"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+```
 
 ```bash
-kubectl run gpu-test --rm -it --restart=Never \
-  --image=nvidia/cuda:12.4.0-base-ubuntu22.04 \
-  --limits=nvidia.com/gpu=1 \
-  -- nvidia-smi
+kubectl apply -f gpu-test.yaml
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/gpu-test --timeout=5m
+kubectl logs gpu-test
+kubectl delete pod gpu-test
 ```
 
 You should see the GPUs listed with driver information. If your nodes have no InfiniBand hardware, you're done — continue to [Next Steps](#next-steps).
@@ -174,7 +200,7 @@ You should see the GPUs listed with driver information. If your nodes have no In
 
 # Part 2 — InfiniBand / RDMA (optional)
 
-> **Only for GPU nodes with Mellanox/NVIDIA ConnectX HCAs.** This section adds the NVIDIA Network Operator (MOFED + the RDMA shared device plugin) and re-enables RDMA in the GPU Operator so multi-node GPU workloads can use the fabric for NCCL. If your nodes have no ConnectX hardware, skip this section entirely. **RoCE clusters** (ConnectX ports in Ethernet mode) complete this section too — where a step below says `Link layer: InfiniBand`, expect `Ethernet` — then continue to [Part 3](#part-3--roce-rail-networks-optional).
+> **Only for GPU nodes with Mellanox/NVIDIA ConnectX HCAs.** This section adds the NVIDIA Network Operator (DOCA-OFED plus the RDMA shared device plugin) so multi-node GPU workloads can use the fabric for NCCL. If your nodes have no ConnectX hardware, skip this section entirely. **RoCE clusters** (ConnectX ports in Ethernet mode) complete this section too — where a step below says `Link layer: InfiniBand`, expect `Ethernet` — then continue to [Part 3](#part-3--roce-rail-networks-optional).
 
 ## Step 4 — Verify IB Hardware
 
@@ -200,46 +226,33 @@ ibstat | grep -E "State|Link layer|Rate"
 # (RoCE clusters: Link layer: Ethernet — expected; continue to Part 3 after this Part)
 ```
 
-### ConnectX Device ID Reference
+### Supported Adapter Families
 
-| Card | PCI device ID |
-| --- | --- |
-| ConnectX-4 | `1013` |
-| ConnectX-5 | `1017` |
-| ConnectX-5 Ex | `1019` |
-| ConnectX-6 | `101b` |
-| ConnectX-6 Dx | `101d` |
-| ConnectX-7 | `1021` |
-| BlueField-2 | `a2d6` |
-| BlueField-3 | `a2dc` |
+Network Operator 26.7 has been validated with ConnectX-6, ConnectX-6 Dx, ConnectX-7, ConnectX-8, ConnectX-9, and BlueField-3 adapters. Protocol support differs by adapter, so check the [Network Operator 26.7 platform support matrix](https://docs.nvidia.com/networking/display/kubernetes2670/platform-support.html) before deployment.
 
-> **Verify against your own hardware** with `lspci -n | grep 15b3` — the device ID in the `15b3:XXXX` pair is what goes into the NicClusterPolicy `deviceIDs` selector.
+Always read the exact PCI device ID from your own hardware with `lspci -n | grep 15b3`. The ID in the `15b3:XXXX` pair is what goes into the NicClusterPolicy `deviceIDs` selector; do not infer it from the product-family name.
 
 ## Step 5 — Install the Network Operator
 
-Pin the chart to **`26.1.1`** (CalVer `YY.MM.PP`). Unpinned installs can pull a newer chart (for example `26.4.0`) whose CRDs/images do not match the NicClusterPolicy below.
+Pin the chart to **`26.7.0`** (CalVer `YY.MM.PP`). This release supports Kubernetes 1.32 through 1.36. Keep the chart, component images, and NicClusterPolicy schema aligned.
 
-Same CRD rule as the GPU Operator: use `helm install` on first deploy (or pre-apply CRDs). `helm upgrade --install` skips `crds/` and fails with `no matches for kind "NodeFeatureRule"`.
+The GPU Operator already supplies Node Feature Discovery. NVIDIA supports only one NFD deployment per cluster, so disable the Network Operator's copy. Network Operator manages its own CRD upgrades through Helm hooks.
 
 ```bash
-helm install network-operator nvidia/network-operator \
+helm upgrade --install network-operator nvidia/network-operator \
   --namespace nvidia-network-operator \
   --create-namespace \
-  --version 26.1.1 \
-  --set deployCR=false \
-  --set nfd.enabled=true
+  --version 26.7.0 \
+  --set nfd.enabled=false
 ```
 
-- `deployCR=false` — apply the `NicClusterPolicy` yourself in the next step.
-- `nfd.enabled=true` — Node Feature Discovery (required; the chart registers `NodeFeatureRule` CRDs).
-
-Later upgrades: `helm upgrade network-operator nvidia/network-operator --version 26.1.1 ...` with the same flags.
+Apply the `NicClusterPolicy` yourself in the next step. On later upgrades, use the same chart version and NFD setting.
 
 ## Step 6 — Apply the NicClusterPolicy
 
 Create `nic-cluster-policy.yaml`. Set `deviceIDs` from Step 4 (`lspci -n | grep 15b3`). Example below uses **`101b`** (ConnectX-6); change it if your cards differ.
 
-Component image tags are pinned to **Network Operator v26.1.1** (`network-operator-v26.1.1` and DOCA driver `doca3.3.0-26.01-1.0.0.0-0`). Keep them aligned with the chart version from Step 5.
+Component image tags are pinned to **Network Operator v26.7.0** (`network-operator-v26.7.0` and DOCA driver `doca3.5.0-26.07-0.7.7.0-0`). Keep them aligned with the chart version from Step 5.
 
 ```yaml
 apiVersion: mellanox.com/v1alpha1
@@ -250,7 +263,7 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: nvcr.io/nvidia/mellanox
-    version: "doca3.3.0-26.01-1.0.0.0-0"
+    version: "doca3.5.0-26.07-0.7.7.0-0"
     upgradePolicy:
       autoUpgrade: true
       maxParallelUpgrades: 1
@@ -264,7 +277,7 @@ spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: nvcr.io/nvidia/mellanox
-    version: "network-operator-v26.1.1"
+    version: "network-operator-v26.7.0"
     config: |
       {
         "configList": [
@@ -283,32 +296,32 @@ spec:
     cniPlugins:
       image: plugins
       repository: nvcr.io/nvidia/mellanox
-      version: "network-operator-v26.1.1"
+      version: "network-operator-v26.7.0"
     multus:
       image: multus-cni
       repository: nvcr.io/nvidia/mellanox
-      version: "network-operator-v26.1.1"
+      version: "network-operator-v26.7.0"
     ipoib:
       image: ipoib-cni
       repository: nvcr.io/nvidia/mellanox
-      version: "network-operator-v26.1.1"
+      version: "network-operator-v26.7.0"
 
   nvIpam:
     image: nvidia-k8s-ipam
     repository: nvcr.io/nvidia/mellanox
-    version: "network-operator-v26.1.1"
+    version: "network-operator-v26.7.0"
     enableWebhook: false
 ```
 
-> **Version tags:** the `doca-driver` and `network-operator-v26.1.1` tags above match Network Operator chart `26.1.1`. If you change the chart version, update these tags from the [NGC catalog](https://catalog.ngc.nvidia.com/) / [Network Operator release notes](https://docs.nvidia.com/networking/display/kubernetes/network-operator).
+> **Version tags:** the `doca-driver` and `network-operator-v26.7.0` tags above match Network Operator chart `26.7.0`. If you change the chart version, update these tags from the [NGC catalog](https://catalog.ngc.nvidia.com/) and [Network Operator release notes](https://docs.nvidia.com/networking/display/kubernetes/network-operator).
 
-**CRD schema notes (Network Operator v26.1.x):**
+**CRD schema notes (Network Operator v26.7.x):**
 
 - `rdmaSharedDevicePlugin` takes a `config` field (a JSON string), **not** a `resources` array.
 - Resource name must be `rdma_shared_device_ib` with `rdmaHcaMax: 63` (Akash interconnect expects this resource).
 - `nvIpam` is a **top-level** `spec` field, **not** nested under `secondaryNetwork`.
 - `secondaryNetwork` accepts only `cniPlugins`, `multus`, and `ipoib`.
-- Component versions should match the operator version (`network-operator-v26.1.1`).
+- Component versions should match the operator version (`network-operator-v26.7.0`).
 
 Apply it:
 
@@ -338,32 +351,11 @@ nv-ipam-node-*          1/1  Running
 network-operator-*      1/1  Running
 ```
 
-## Step 7 — Enable RDMA in the GPU Operator
+## Step 7 — Keep DMA-BUF as the GPUDirect path
 
-Now that MOFED is available, re-enable RDMA in the GPU Operator so the driver loads `nvidia-peermem` for GPUDirect RDMA. Edit `gpu-operator-values.yaml`:
+GPU Operator 26.7 uses DMA-BUF for the standard GPUDirect RDMA path. Keep `driver.rdma.enabled: false`; enabling it specifically opts into the legacy `nvidia-peermem` module and is not required for general InfiniBand or RoCE support.
 
-```yaml
-driver:
-  enabled: true
-  rdma:
-    enabled: true        # ← Now true; MOFED is present
-    useHostMofed: false
-```
-
-Re-apply (chart already installed — `helm upgrade` is correct here; CRDs are already present):
-
-```bash
-helm upgrade gpu-operator nvidia/gpu-operator \
-  --namespace gpu-operator \
-  --version v26.3.3 \
-  -f gpu-operator-values.yaml
-```
-
-The GPU driver daemonset rolls; the driver init container detects MOFED and loads `nvidia-peermem`. Wait for the driver pods and `nvidia-operator-validator` to return to `Running`/complete:
-
-```bash
-kubectl -n gpu-operator get pods -w
-```
+DMA-BUF requires an open NVIDIA kernel module, Linux kernel 5.12 or later, CUDA 11.7 or later, and a supported Turing-or-newer GPU. If your hardware or software does not meet those [GPUDirect RDMA prerequisites](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-rdma.html), use the documented `nvidia-peermem` fallback. Wait for the Network Operator's driver pods first, set `driver.rdma.enabled: true`, reconcile the GPU Operator CRDs as shown in Step 2, and upgrade the GPU Operator release.
 
 ## Step 8 — Verify RDMA
 
@@ -381,50 +373,77 @@ node1 rdma=63
 node2 rdma=63
 ```
 
-### Cross-Node Bandwidth Test
+### Cross-Node GPUDirect Bandwidth Test
 
-Server on `node1`:
+Create two long-running test pods on different GPU nodes. Replace `node1` and `node2` if your Kubernetes node names differ:
 
-```bash
-kubectl run ib-server --image=mellanox/rping-test --restart=Never \
-  --overrides='{
-    "spec": {
-      "nodeName": "node1",
-      "containers": [{
-        "name": "s",
-        "image": "mellanox/rping-test",
-        "command": ["ib_write_bw", "-d", "mlx5_0", "--report_gbits"],
-        "resources": {"limits": {"rdma/rdma_shared_device_ib": "1"}},
-        "securityContext": {"capabilities": {"add": ["IPC_LOCK"]}}
-      }]
-    }
-  }'
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ib-server
+spec:
+  nodeName: node1
+  restartPolicy: Never
+  containers:
+    - name: perf
+      image: mellanox/cuda-perftest
+      command: ["sleep", "infinity"]
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+          rdma/rdma_shared_device_ib: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ib-client
+spec:
+  nodeName: node2
+  restartPolicy: Never
+  containers:
+    - name: perf
+      image: mellanox/cuda-perftest
+      command: ["sleep", "infinity"]
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+          rdma/rdma_shared_device_ib: 1
 ```
 
-Client on `node2`:
+Save the manifest as `ib-gpu-test.yaml`, apply it, and wait for both pods:
 
 ```bash
-SERVER_IP=$(kubectl get pod ib-server -o jsonpath='{.status.podIP}')
-
-kubectl run ib-client --image=mellanox/rping-test --restart=Never \
-  --overrides="{
-    \"spec\": {
-      \"nodeName\": \"node2\",
-      \"containers\": [{
-        \"name\": \"c\",
-        \"image\": \"mellanox/rping-test\",
-        \"command\": [\"ib_write_bw\", \"-d\", \"mlx5_0\", \"$SERVER_IP\", \"--report_gbits\"],
-        \"resources\": {\"limits\": {\"rdma/rdma_shared_device_ib\": \"1\"}},
-        \"securityContext\": {\"capabilities\": {\"add\": [\"IPC_LOCK\"]}}
-      }]
-    }
-  }"
-
-kubectl logs ib-client
-# Approximate full-port line rates: ~197 Gb/s (HDR), ~100 Gb/s (HDR100 / EDR)
-
-kubectl delete pod ib-server ib-client
+kubectl apply -f ib-gpu-test.yaml
+kubectl wait --for=condition=Ready pod/ib-server pod/ib-client --timeout=5m
+kubectl get pods ib-server ib-client -o wide
 ```
+
+In the first terminal, start the server. If the allocated HCA is not `mlx5_0`, substitute the correct device:
+
+```bash
+kubectl exec -it ib-server -- \
+  ib_write_bw --use_cuda=0 --use_cuda_dmabuf \
+  -d mlx5_0 -a -F --report_gbits -q 1
+```
+
+In a second terminal, connect with the server pod IP shown by `kubectl get pods -o wide`:
+
+```bash
+kubectl exec -it ib-client -- \
+  ib_write_bw -n 5000 --use_cuda=0 --use_cuda_dmabuf \
+  -d mlx5_0 -a -F --report_gbits -q 1 <ib-server-pod-ip>
+
+kubectl delete -f ib-gpu-test.yaml
+```
+
+Both pods request a GPU and an RDMA device, and `--use_cuda_dmabuf` makes this a GPU-memory test rather than a host-memory RDMA test.
 
 > **NCCL configuration is handled by the Akash provider.** You do not configure NCCL on the cluster. When a tenant requests GPU interconnect in the SDL, the provider auto-injects the NCCL environment (`NCCL_IB_DISABLE=0`, `NCCL_IB_HCA` from the node's discovered HCA families) and requests one `rdma/rdma_shared_device_ib` handle per GPU. On RoCE fabrics it additionally attaches the rail networks from [Part 3](#part-3--roce-rail-networks-optional) so NCCL can select the pod's own RoCEv2 GID. Provider setup ends once the node advertises the GPU and RDMA resources verified above.
 
@@ -451,8 +470,20 @@ Each rail NIC needs a host IP in its own per-rail subnet (one `/24` per rail is 
 network:
   version: 2
   ethernets:
-    enp26s0np0:  { mtu: 9000, accept-ra: false, optional: true, addresses: [10.100.0.11/24] }
-    enp60s0np0:  { mtu: 9000, accept-ra: false, optional: true, addresses: [10.100.1.11/24] }
+    enp26s0np0:
+      {
+        mtu: 9000,
+        accept-ra: false,
+        optional: true,
+        addresses: [10.100.0.11/24],
+      }
+    enp60s0np0:
+      {
+        mtu: 9000,
+        accept-ra: false,
+        optional: true,
+        addresses: [10.100.1.11/24],
+      }
     # ... one per rail; keep the host octet (.11 here) identical across rails,
     # unique per node. No gateways, no routes — each rail is a directly
     # attached /24; the default route stays on your management network.
@@ -465,12 +496,13 @@ Verify on each node:
 ibstat | grep "Link layer"
 # Link layer: Ethernet          ← RoCE (all ports)
 
-# GID index 3 = RoCEv2 over the rail IPv4 address (host-side sanity check)
+# List the RoCEv2 entries and note the GID index for this rail
 show_gids | awk '$5=="v2" && $4!=""'
 
-# Cross-node raw bandwidth per rail (server on node A, client on node B):
-#   A: ib_write_bw -d mlx5_0 -x 3 --report_gbits
-#   B: ib_write_bw -d mlx5_0 -x 3 <node-A-rail-IP> --report_gbits
+# Optional host-memory transport check per rail. Substitute the RoCEv2 GID
+# index reported above on each host (server on node A, client on node B):
+#   A: ib_write_bw -d mlx5_0 -x <server-gid-index> --report_gbits
+#   B: ib_write_bw -d mlx5_0 -x <client-gid-index> <node-A-rail-IP> --report_gbits
 # Expect the port line rate (e.g. ~391 Gb/s on 400G CX-7).
 ```
 
@@ -549,9 +581,15 @@ spec:
         labelSelector: { matchLabels: { app: roce-test } }
   containers:
   - name: perf
-    image: ubuntu:24.04
-    command: ["bash","-lc","apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq perftest >/dev/null && echo READY && sleep infinity"]
-    resources: { limits: { "rdma/rdma_shared_device_ib": "1" } }
+    image: mellanox/cuda-perftest
+    command: ["sleep", "infinity"]
+    securityContext:
+      capabilities:
+        add: ["IPC_LOCK"]
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+        rdma/rdma_shared_device_ib: 1
 YAML
 kubectl label pod roce-test-$p app=roce-test
 done
@@ -566,11 +604,16 @@ kubectl exec roce-test-a -- bash -c \
   'grep -rl "RoCE v2" /sys/class/infiniband/mlx5_0/ports/1/gid_attrs/types 2>/dev/null | head -1'
 # The trailing number of that path is the GID index (typically 4 or 5)
 
-# Bandwidth (use the GID index from above, e.g. 5):
+# GPUDirect bandwidth (use each pod's matching rail HCA and GID index):
 # terminal 1:
-kubectl exec -it roce-test-a -- ib_write_bw -d mlx5_0 -x 5 --report_gbits
+kubectl exec -it roce-test-a -- \
+  ib_write_bw --use_cuda=0 --use_cuda_dmabuf \
+  -d mlx5_0 -x <server-gid-index> -a -F --report_gbits -q 1
 # terminal 2 (target = roce-test-a's rail0 IP from `ip -br addr`):
-kubectl exec -it roce-test-b -- ib_write_bw -d mlx5_0 -x 5 <rail0-ip-of-a> --report_gbits
+kubectl exec -it roce-test-b -- \
+  ib_write_bw -n 5000 --use_cuda=0 --use_cuda_dmabuf \
+  -d mlx5_0 -x <client-gid-index> -a -F --report_gbits -q 1 \
+  <rail0-ip-of-a>
 # Expect port line rate, matching the raw host test from Step 9
 
 kubectl delete pod roce-test-a roce-test-b
@@ -594,39 +637,34 @@ Adding InfiniBand or RoCE:
   4. Network Operator (helm)
   5. NicClusterPolicy → MOFED compile + RDMA device plugin
         ↓ wait for MOFED pods Running
-  6. GPU Operator helm upgrade (driver.rdma.enabled: true)
-        ↓ driver reloads, loads nvidia-peermem
-  7. Nodes report nvidia.com/gpu AND rdma/rdma_shared_device_ib
+  6. Nodes report nvidia.com/gpu AND rdma/rdma_shared_device_ib
 
 RoCE only (Part 3):
-  8. Rail IP addressing on hosts (netplan, one /24 per rail)
-  9. akash-rails namespace: IPPool + MacvlanNetwork per rail
- 10. Provider attaches the rails to RoCE interconnect pods automatically
+  7. Rail IP addressing on hosts (netplan, one /24 per rail)
+  8. akash-rails namespace: IPPool + MacvlanNetwork per rail
+  9. Provider attaches the rails to RoCE interconnect pods automatically
 ```
 
 ---
 
 ## Troubleshooting
 
-**`no matches for kind "ClusterPolicy"` or `"NodeFeatureRule"`** — Helm skipped CRDs because the release was created with `helm upgrade --install`. On first deploy use `helm install`, **or** pre-apply CRDs then upgrade:
+**`no matches for kind "ClusterPolicy"` or `"NodeFeatureRule"` from GPU Operator** — reconcile both bundled sets of CRDs before installing or upgrading:
 
 ```bash
 # GPU Operator CRDs
-helm pull nvidia/gpu-operator --version v26.3.3 --untar
-kubectl create -f gpu-operator/crds/
+rm -rf /tmp/akash-gpu-operator-chart
+helm pull nvidia/gpu-operator --version v26.7.0 --untar \
+  --untardir /tmp/akash-gpu-operator-chart
+kubectl apply --server-side --force-conflicts \
+  -f /tmp/akash-gpu-operator-chart/gpu-operator/crds \
+  -f /tmp/akash-gpu-operator-chart/gpu-operator/charts/node-feature-discovery/crds/nfd-api-crds.yaml
 helm upgrade -i gpu-operator nvidia/gpu-operator \
   --namespace gpu-operator --create-namespace \
-  --version v26.3.3 -f gpu-operator-values.yaml
-
-# Network Operator CRDs
-helm pull nvidia/network-operator --version 26.1.1 --untar
-kubectl create -f network-operator/crds/
-helm upgrade -i network-operator nvidia/network-operator \
-  --namespace nvidia-network-operator --create-namespace \
-  --version 26.1.1 --set deployCR=false --set nfd.enabled=true
+  --version v26.7.0 -f gpu-operator-values.yaml
 ```
 
-**GPU driver pod stuck in `Init:0/1`** — the driver init container is waiting for MOFED. This happens when `driver.rdma.enabled: true` but the Network Operator/MOFED is not ready. Either finish Part 2 or set `driver.rdma.enabled: false`.
+**GPU driver pod stuck in `Init:0/1` after opting into `nvidia-peermem`** — the driver init container is waiting for MOFED. This applies only when `driver.rdma.enabled: true`. Either finish the Network Operator deployment or return to the default DMA-BUF configuration with `driver.rdma.enabled: false`.
 
 ```bash
 kubectl -n nvidia-network-operator get pods | grep mofed
@@ -665,5 +703,4 @@ Your cluster now has GPU support (and optionally InfiniBand or RoCE RDMA).
 - [Provider installation – STEP 9 (TLS)](/docs/providers/setup-and-installation/kubespray/provider-installation-prep#step-9---lets-encrypt-cert-manager-and-tls-secrets) — **required** for all providers: cert-manager and Gateway TLS
 - [IP Leases](/docs/providers/setup-and-installation/kubespray/ip-leases) — enable static IPs
 
-> **Note:** After installing the provider, add GPU attributes to your `provider.yaml` to advertise GPU capabilities — and `capabilities/gpu-interconnect` plus `capabilities/gpu-interconnect/fabric/infiniband` (Part 2) or `.../fabric/roce` (Parts 2 + 3). See [Provider Attributes — GPU Interconnect](/docs/providers/operations/provider-attributes/#gpu-interconnect-infiniband--roce).
-
+> **Note:** The Provider Playbook renders GPU model, RAM, interface, and CUDA attributes automatically. If you follow this manual guide, add those GPU attributes to `provider.yaml` yourself. Interconnect providers must also add `capabilities/gpu-interconnect` and the matching `.../fabric/infiniband` or `.../fabric/roce` key. See [Provider Attributes — GPU Interconnect](/docs/providers/operations/provider-attributes/#gpu-interconnect-infiniband--roce).

--- a/src/content/Docs/providers/setup-and-installation/kubespray/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/index.md
@@ -11,7 +11,7 @@ description: "Manual provider setup using Kubespray and Helm for full control"
 
 Kubespray provides a manual, step-by-step approach to deploying an Akash provider, giving you full control and customization over every component. Ideal for advanced users who need specific configurations or want to deeply understand the infrastructure.
 
- **Setup Time:** 1-2 hours
+**Setup Time:** 1-2 hours
 
 ---
 
@@ -19,7 +19,7 @@ Kubespray provides a manual, step-by-step approach to deploying an Akash provide
 
 Kubespray is a composition of Ansible playbooks, inventory, provisioning tools, and domain knowledge for deploying production-ready Kubernetes clusters. For Akash providers, we use:
 
-- **Kubespray 2.31.0** - Latest stable release
+- **Kubespray 2.31.0** - Pinned release used by Provider Playbook
 - **Kubernetes 1.35.4** - Officially supported version
 - **etcd 3.6.10** - Distributed key-value store
 - **containerd 2.2.3** - Container runtime
@@ -30,6 +30,7 @@ Kubespray is a composition of Ansible playbooks, inventory, provisioning tools, 
 ## Why Choose Kubespray?
 
 ### **Advantages**
+
 - **Full control** - Customize every aspect of your setup
 - **Production-grade** - Battle-tested for large deployments
 - **Deep understanding** - Learn exactly how components work together
@@ -37,7 +38,8 @@ Kubespray is a composition of Ansible playbooks, inventory, provisioning tools, 
 - **Custom configurations** - Fine-tune network, storage, and security
 - **Reproducible** - Infrastructure as Code approach
 
-###  Considerations
+### Considerations
+
 - **Requires Kubernetes knowledge** - Must understand K8s concepts
 - **More manual steps** - Less automated than Provider Playbook
 - **Command-line focused** - Terminal-based setup
@@ -48,12 +50,14 @@ Kubespray is a composition of Ansible playbooks, inventory, provisioning tools, 
 ## Prerequisites
 
 ### Required Knowledge
+
 - **Linux administration** - Comfortable with command line and SSH
 - **Kubernetes fundamentals** - Understand pods, deployments, services, namespaces
 - **Networking basics** - IP addressing, DNS, firewalls, routing
 - **Ansible basics** - Understand playbook concepts (helpful but not required)
 
 ### Hardware & System Requirements
+
 See [Hardware Requirements](/docs/providers/getting-started/hardware-requirements) for complete specifications including CPU, RAM, storage, network, and GPU requirements.
 
 ---
@@ -62,39 +66,50 @@ See [Hardware Requirements](/docs/providers/getting-started/hardware-requirement
 
 The Kubespray setup is divided into distinct steps:
 
-### Phase 1: Core Setup (Required)
+### Phase 1: Kubernetes foundation (Required)
 
 **1. [Kubernetes Cluster Setup](/docs/providers/setup-and-installation/kubespray/kubernetes-setup)**
+
 - Clone Kubespray repository
 - Configure inventory and variables
 - Deploy Kubernetes cluster with Ansible
 - Verify cluster health
 
-**2. Provider installation (two parts)**
-- **[Provider installation (prep)](/docs/providers/setup-and-installation/kubespray/provider-installation-prep)** — wallet, `provider.yaml`, **DNS**, **NGF**, and **Let's Encrypt** (steps 1–9)
-- **[Provider installation (install)](/docs/providers/setup-and-installation/kubespray/provider-installation)** — `akash-gateway`, operators, and `helm install` for the [Akash provider](https://github.com/akash-network/helm-charts/tree/main/charts/akash-provider)
-- Verify the provider is running
-
-### Phase 2: Optional Features
+### Phase 2: Provider capabilities (Optional)
 
 Add advanced capabilities based on your hardware and business needs:
 
-**3. [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support)**
-- Install NVIDIA drivers and container toolkit
-- Deploy NVIDIA device plugin
+**2. [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support)**
+
+- Deploy NVIDIA GPU Operator
+- Configure CDI and the container runtime
 - Configure GPU attributes
 - Test GPU workloads
 
-**4. [Persistent Storage](/docs/providers/setup-and-installation/kubespray/persistent-storage)**
+**3. [Persistent Storage](/docs/providers/setup-and-installation/kubespray/persistent-storage)**
+
 - Deploy Rook-Ceph operator
 - Configure OSD devices
 - Create storage classes (beta1/beta2/beta3)
 - Test persistent volumes
 
+Install GPU and storage before rendering the provider configuration so its advertised attributes match the available cluster capabilities.
+
+### Phase 3: Provider installation (Required)
+
+**4. Provider installation (two parts)**
+
+- **[Provider installation (prep)](/docs/providers/setup-and-installation/kubespray/provider-installation-prep)** — wallet, `provider.yaml`, **DNS**, **NGF**, and **Let's Encrypt** (steps 1–9)
+- **[Provider installation (install)](/docs/providers/setup-and-installation/kubespray/provider-installation)** — `akash-gateway`, operators, and `helm install` for the [Akash provider](https://github.com/akash-network/helm-charts/tree/main/charts/akash-provider)
+- Verify the provider is running
+
+### Phase 4: Additional features (Optional)
+
 **5. [IP Leases](/docs/providers/setup-and-installation/kubespray/ip-leases)**
-- Configure IP address pool
-- Deploy MetalLB load balancer
-- Enable IP lease operator
+
+- Configure an IP address pool
+- Deploy the MetalLB load balancer
+- Enable the IP lease operator
 - Test static IP assignment
 
 ---
@@ -103,30 +118,33 @@ Add advanced capabilities based on your hardware and business needs:
 
 ### Start Simple, Add Complexity
 
-**Step 1: Get Basic Provider Running**
+**Step 1: Install the provider stack**
+
 1. Deploy Kubernetes cluster (Kubespray)
-2. Install provider software (Helm)
-3. Test with a simple deployment
-4. Verify provider shows up on network
+2. Enable GPU support if the provider has NVIDIA GPUs
+3. Configure persistent storage if the provider will advertise it
+4. Install the provider software with the resulting attributes
+5. Test with a simple deployment
+6. Verify the provider shows up on network
 
 **Goal:** Prove your infrastructure works
 
 ---
 
-**Step 2: Add Revenue Features**
-5. Enable GPU support (if you have GPUs)
-6. Configure persistent storage (if you have dedicated drives)
-7. Set up IP leases (if you have extra IPs)
+**Step 2: Add more capabilities**
+
+1. Set up IP leases if you have extra public IPs
 
 **Goal:** Maximize earning potential
 
 ---
 
 **Step 3: Optimize & Scale**
-8. Fine-tune pricing based on market
-9. Monitor metrics and performance
-10. Add capacity as needed
-11. Automate maintenance tasks
+
+1. Fine-tune pricing based on market
+2. Monitor metrics and performance
+3. Add capacity as needed
+4. Automate maintenance tasks
 
 **Goal:** Maximize profitability and uptime
 
@@ -135,17 +153,20 @@ Add advanced capabilities based on your hardware and business needs:
 ## Time Estimates
 
 ### First-Time Setup
+
 - **Kubernetes cluster:** 30-45 minutes
 - **Provider installation:** 30-45 minutes
 - **Configuration & testing:** 15-30 minutes
 - **Total:** ~1-2 hours
 
 ### Optional Features
+
 - **GPU support:** 30-60 minutes
 - **Persistent storage:** 45-90 minutes (depending on complexity)
 - **IP leases:** 30-45 minutes
 
 ### Experienced Operators
+
 - **Full setup:** 45-60 minutes
 - **With automation:** 20-30 minutes
 
@@ -155,18 +176,19 @@ Add advanced capabilities based on your hardware and business needs:
 
 ## Kubespray vs Provider Playbook
 
-Both methods use Kubespray, but with different levels of automation:
+The manual path always uses Kubespray. Provider Playbook can build with Kubespray or K3s, or install onto an existing Kubernetes cluster:
 
-| Feature | Kubespray (This Guide) | Provider Playbook |
-|---------|------------------------|-------------------|
-| **Automation** | Manual steps | Interactive script |
-| **Control** | Full control | Guided configuration |
-| **Time** | 1-2 hours | ~1 hour |
-| **Skill Level** | Advanced | Intermediate |
-| **Customization** | Maximum | Standard options |
-| **Best For** | Custom setups, learning | Quick deployment |
+| Feature           | Kubespray (This Guide)  | Provider Playbook    |
+| ----------------- | ----------------------- | -------------------- |
+| **Automation**    | Manual steps            | Interactive script   |
+| **Control**       | Full control            | Guided configuration |
+| **Time**          | 1-2 hours               | ~1 hour              |
+| **Skill Level**   | Advanced                | Intermediate         |
+| **Customization** | Maximum                 | Standard options     |
+| **Best For**      | Custom setups, learning | Quick deployment     |
 
 **Use Kubespray when you:**
+
 - Need specific Kubernetes configurations
 - Want to understand every component
 - Have custom networking requirements
@@ -174,6 +196,7 @@ Both methods use Kubespray, but with different levels of automation:
 - Need fine-grained control over resources
 
 **Use Provider Playbook when you:**
+
 - Want the fastest setup
 - Prefer guided configuration
 - Are setting up a standard provider
@@ -193,6 +216,7 @@ Unlike Provider Playbook's automated script, the Kubespray method requires you t
 6. **Manage updates** - Manually apply upgrades and patches
 
 **However, you gain:**
+
 - Deep understanding of the infrastructure
 - Ability to customize anything
 - Fine-grained control over security
@@ -206,31 +230,36 @@ Unlike Provider Playbook's automated script, the Kubespray method requires you t
 Not sure Kubespray is right for you?
 
 **[Provider Playbook →](/docs/providers/setup-and-installation/provider-playbook)**
-- Automated Kubespray setup with interactive wizard
-- Same Kubernetes stack, automated configuration
+
+- Interactive wizard for Kubespray, K3s, or an existing cluster
+- Automated detection and validated configuration
 - Recommended for most users
--  Time: ~1 hour
+- Time: ~1 hour
 
 **[Provider Console →](/docs/providers/setup-and-installation/provider-console)**
+
 - Web-based setup with no K8s knowledge required
 - Fully managed Kubernetes
 - Best for beginners
--  Time: 15-30 minutes
+- Time: 15-30 minutes
 
 ---
 
 ## Getting Help
 
 ### Before You Start
+
 - Review [Hardware Requirements](/docs/providers/getting-started/hardware-requirements)
 - Read [Should I Run a Provider?](/docs/providers/getting-started/should-i-run-a-provider)
 - Calculate earnings with [Provider Calculator](https://akash.network/pricing/provider-calculator/)
 
 ### During Setup
+
 - **Discord:** [discord.akash.network](https://discord.akash.network) - #providers channel
 - **Kubespray Docs:** [kubespray.io](https://kubespray.io)
 
 ### After Setup
+
 - [Operations Guide →](/docs/providers/operations) - Managing your provider
 - [Provider Verification →](/docs/providers/operations/provider-verification) - Verify your setup
 
@@ -243,4 +272,3 @@ Start with the Kubernetes cluster setup:
 **→ [Kubernetes Setup Guide](/docs/providers/setup-and-installation/kubespray/kubernetes-setup)**
 
 This will walk you through deploying a production-grade Kubernetes cluster using Kubespray 2.31.0.
-

--- a/src/content/Docs/providers/setup-and-installation/kubespray/ip-leases/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/ip-leases/index.md
@@ -9,7 +9,7 @@ description: "Enable leased IP support on an Akash provider with MetalLB and aka
 
 # IP Leases — Provider Setup (MetalLB + akash-ip-operator)
 
-This guide enables leased IP support on an Akash provider. It reflects verified behavior as of July 2026 (provider image `0.14.2`, MetalLB chart `0.14.9`, Kubernetes with kubespray/Calico) and includes a troubleshooting table with exact error strings.
+This guide enables leased IP support on an Akash provider. It targets provider image `0.16.2`, Akash IP Operator chart `19.0.2`, MetalLB chart `0.14.9`, and Kubernetes with Kubespray/Calico. The MetalLB pin is intentional because the provider still discovers and reads the controller's plaintext metrics endpoint.
 
 IP leases are **optional**. If you do not intend to offer dedicated IPs, do not install the IP operator — nothing else in the provider stack depends on it.
 
@@ -28,7 +28,7 @@ IP leases are **optional**. If you do not intend to offer dedicated IPs, do not 
 - Your provider's on-chain address (`akash1...`). Retrieve it with:
 
   ```bash
-  provider-services keys show <keyname> -a --keyring-backend file
+  akt context keys show <keyname> --address
   ```
 
 - A block of public IPs **delivered on the same L2 segment (VLAN) as a node interface**. MetalLB L2 mode answers ARP for these IPs; if your datacenter routes the block elsewhere or the node only has private/NAT addressing, L2 mode will not work (see troubleshooting item 6).
@@ -65,7 +65,7 @@ Kubernetes only creates SRV records for **named** service ports. The service mus
 ```bash
 kubectl -n metallb-system expose deployment metallb-controller \
   --name=controller \
-  --overrides='{"spec":{"ports":[{"protocol":"TCP","name":"monitoring","port":7472}]}}'
+  --overrides='{"apiVersion":"v1","spec":{"ports":[{"protocol":"TCP","name":"monitoring","port":7472}]}}'
 ```
 
 Verify all three properties:
@@ -91,7 +91,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-    - 64.31.61.235-64.31.61.238   # your public range
+    - 64.31.61.235-64.31.61.238 # your public range
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -132,6 +132,7 @@ kubectl label node <node> node.kubernetes.io/exclude-from-external-load-balancer
 
 ```bash
 helm install akash-ip-operator akash/akash-ip-operator -n akash-services \
+  --version 19.0.2 \
   --set provider_address=<your akash1... address>
 ```
 
@@ -175,6 +176,7 @@ Then upgrade the provider and update the on-chain provider record:
 
 ```bash
 helm upgrade akash-provider akash/provider -n akash-services -f provider.yaml \
+  --version 19.0.2 \
   --set bidpricescript="$(cat price_script.sh | openssl base64 -A)"
 ```
 

--- a/src/content/Docs/providers/setup-and-installation/kubespray/kubernetes-setup/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/kubernetes-setup/index.md
@@ -11,7 +11,7 @@ description: "Deploy a production-grade Kubernetes cluster using Kubespray 2.31.
 
 This guide walks through deploying a production-ready Kubernetes cluster that will host your Akash provider. The cluster will run all provider leases as Kubernetes pods.
 
- **Time:** 30-45 minutes
+**Time:** 30-45 minutes
 
 ---
 
@@ -29,6 +29,7 @@ Using Kubespray 2.31.0, you'll install:
 ## Before You Begin
 
 Ensure you have:
+
 - **Reviewed [Hardware Requirements](/docs/providers/getting-started/hardware-requirements)**
 - **Ubuntu 24.04 LTS installed on all nodes**
 - **Root or sudo access to all nodes**
@@ -144,6 +145,7 @@ nano ~/kubespray/inventory/akash/inventory.ini
 ```
 
 Configure your nodes in the inventory. **Important:**
+
 - Use **1 or 3** control plane nodes (odd numbers for consensus)
 - List the same nodes under both `[kube_control_plane]` and `[etcd]`
 - Add all worker nodes under `[kube_node]`
@@ -215,27 +217,13 @@ upstream_dns_servers:
 
 ---
 
-## STEP 7 - Configure GPU Support (OPTIONAL)
+## STEP 7 - Prepare for GPU Support (OPTIONAL)
 
 > **Skip this step** if you don't have NVIDIA GPUs.
 
-If you have NVIDIA GPUs, configure the container runtime **before** deploying the cluster:
+GPU Operator 26.7 uses Container Device Interface (CDI) and configures the required runtime integration after Kubernetes is available. Do not add a legacy `containerd_additional_runtimes` entry and do not preinstall an NVIDIA driver, CUDA driver package, NVIDIA Container Toolkit, or standalone device plugin.
 
-```bash
-mkdir -p ~/kubespray/inventory/akash/group_vars/all
-cat > ~/kubespray/inventory/akash/group_vars/all/akash.yml << 'EOF'
-# NVIDIA container runtime for GPU-enabled nodes
-containerd_additional_runtimes:
-  - name: nvidia
-    type: "io.containerd.runc.v2"
-    engine: ""
-    root: ""
-    options:
-      BinaryName: '/usr/bin/nvidia-container-runtime'
-EOF
-```
-
-This configures containerd to support GPU workloads. The actual NVIDIA drivers and device plugin will be installed later.
+Deploy Kubernetes with ordinary containerd, then follow [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support). The Provider Playbook enforces this clean-node requirement automatically.
 
 ---
 
@@ -294,6 +282,7 @@ etcdctl check perf
 ```
 
 **Expected output from `etcdctl check perf`:**
+
 ```
 ...
 PASS: Throughput is 150 writes/s
@@ -454,10 +443,12 @@ This runs every 5 minutes and logs output to syslog.
 Ensure these ports are open between nodes:
 
 **Control Plane:**
+
 - `6443/tcp` - Kubernetes API server
 - `2379-2380/tcp` - etcd client and peer
 
 **All Nodes:**
+
 - `10250/tcp` - Kubelet API
 
 See [Kubernetes port reference](https://kubernetes.io/docs/reference/ports-and-protocols/) for a complete list.
@@ -472,9 +463,10 @@ See [Kubernetes port reference](https://kubernetes.io/docs/reference/ports-and-p
 
 ## Next Steps
 
-Your Kubernetes cluster is now ready!
-- Otherwise: **→ [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation)**
+Your Kubernetes cluster is now ready. Complete the remaining setup in this order:
 
-**Additional optional features:**
-- [Provider installation – STEP 9 (TLS)](/docs/providers/setup-and-installation/kubespray/provider-installation-prep#step-9---lets-encrypt-cert-manager-and-tls-secrets) - **Required** for all providers: cert-manager and Gateway TLS
-- [IP Leases](/docs/providers/setup-and-installation/kubespray/ip-leases) - Enable static IPs for deployments
+1. If you have NVIDIA GPUs, configure [GPU Support](/docs/providers/setup-and-installation/kubespray/gpu-support).
+2. If you offer persistent storage, configure [Persistent Storage](/docs/providers/setup-and-installation/kubespray/persistent-storage).
+3. Complete [Provider Installation Preparation](/docs/providers/setup-and-installation/kubespray/provider-installation-prep).
+4. [Install the Provider](/docs/providers/setup-and-installation/kubespray/provider-installation).
+5. After the provider is installed, optionally enable [IP Leases](/docs/providers/setup-and-installation/kubespray/ip-leases).

--- a/src/content/Docs/providers/setup-and-installation/kubespray/persistent-storage/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/persistent-storage/index.md
@@ -7,159 +7,101 @@ linkTitle: "Persistent Storage"
 description: "Enable persistent storage on your Akash provider using Rook-Ceph"
 ---
 
-> **Don't need persistent storage?** Skip to [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation).
+This guide installs Rook-Ceph with exact dedicated disks and exposes one Akash persistent-storage class. Complete it before [installing the provider](/docs/providers/setup-and-installation/kubespray/provider-installation) so the provider advertises the storage it can actually provision.
 
-This guide shows how to enable persistent storage on your Akash provider using Rook-Ceph. The default configuration targets **NVMe** drives and the **`beta3`** storage class.
+The automated [Provider Playbook](/docs/providers/setup-and-installation/provider-playbook) performs read-only disk discovery, recommends a topology, and validates the resulting OSDs and StorageClass. Use that path unless you specifically need a manual Rook configuration.
 
-**Time:** 45-60 minutes
+## Requirements and topology
 
----
+Ceph needs at least two dedicated physical disks across the cluster and creates one OSD per disk, including NVMe. For production host-failure tolerance, use at least three storage hosts.
 
-## Prerequisites
+| Storage layout                   | Pool size | Minimum replicas | Failure domain | Protection                              |
+| -------------------------------- | --------: | ---------------: | -------------- | --------------------------------------- |
+| Three or more storage hosts      |         3 |                2 | `host`         | Recommended; tolerates a host failure   |
+| Two storage hosts                |         2 |                1 | `host`         | Limited host redundancy                 |
+| One host with at least two disks |         2 |                1 | `osd`          | Disk failure only; no host availability |
 
-Before starting, ensure you have:
+Use homogeneous media when possible. If you intentionally mix media, advertise the class of the slowest selected disk:
 
-### Hardware Requirements
+| Media | Akash StorageClass |
+| ----- | ------------------ |
+| HDD   | `beta1`            |
+| SSD   | `beta2`            |
+| NVMe  | `beta3`            |
 
-See [Hardware Requirements - Persistent Storage](/docs/providers/getting-started/hardware-requirements#persistent-storage-optional) for detailed specifications:
-- **Recommended (default in this guide):** NVMe drives — minimum 2 NVMe SSDs across all nodes
-- **Alternative:** 4 SATA/SAS SSDs across all nodes (use `beta2` / `osdsPerDevice: "1"` instead)
-- **Drives must be:**
-  - Dedicated exclusively to persistent storage
-  - Unformatted (no partitions or filesystems)
-  - NOT used for OS or ephemeral storage
-- **Recommended:** Distribute across multiple nodes for redundancy
+This guide uses three NVMe disks on three hosts and creates `beta3`.
 
-### Network Requirements
+## 1. Identify eligible disks
 
-- **Minimum:** 10 GbE NIC cards for storage nodes
-- **Recommended:** 25 GbE or faster for better performance
+On every storage host, inspect whole disks and their stable identities:
 
-### Ceph Requirements
+```bash
+lsblk --exclude 7 --output NAME,PATH,SIZE,TYPE,FSTYPE,MOUNTPOINTS,ROTA,RO,RM
+ls -l /dev/disk/by-id/
+```
 
-For production use:
-- **Minimum 3 OSDs** for redundancy and high availability
-- **Minimum 2 Ceph managers**
-- **Minimum 3 Ceph monitors**
-- **Minimum 60 GB** disk space at `/var/lib/ceph/` (each monitor requires 60 GB)
+A Ceph disk must be:
 
-**OSDs per drive:**
-- HDD: 1 OSD max
-- SSD: 1 OSD max
-- NVMe: 2 OSDs max (default in this guide)
+- A dedicated, non-removable whole disk of at least 5 GiB.
+- Unpartitioned and not mounted or used as swap.
+- Free of filesystem, RAID, LVM, and Ceph signatures.
+- Free of active block-device holders.
+- Addressable through a stable `/dev/disk/by-id/...` symlink.
 
-> **Important:** Do NOT run multiple OSDs on a single SAS/SATA drive. NVMe drives can achieve improved performance with 2 OSDs per drive.
+Check a candidate before selecting it:
 
----
+```bash
+sudo wipefs --no-act /dev/nvme0n1
+findmnt --source /dev/nvme0n1
+swapon --show
+sudo pvs
+readlink -f /dev/disk/by-id/nvme-example-disk-id
+```
 
-## STEP 1 - Identify Storage Nodes and Devices
+No output from `wipefs --no-act` is necessary but not sufficient proof that a disk contains no valuable data. Confirm each disk's ownership through your infrastructure records before proceeding. Rook will consume every selected disk.
 
-### List Available Nodes
+Do not use a broad device filter such as `nvme*`. Record the exact stable ID for each disk and the Kubernetes node name returned by:
 
 ```bash
 kubectl get nodes
 ```
 
-### Check Available Drives
+## 2. Install the Rook-Ceph operator
 
-SSH into each potential storage node and list unformatted drives:
-
-```bash
-lsblk -f
-```
-
-Look for drives with no `FSTYPE` (unformatted). Example NVMe output:
-
-```
-NAME        FSTYPE LABEL UUID                                 MOUNTPOINT
-nvme0n1
-nvme1n1
-nvme2n1
-nvme0n2   ext4         a1b2c3d4-5678-90ab-cdef-1234567890ab /
-```
-
-In this example, `nvme0n1`, `nvme1n1`, and `nvme2n1` are unformatted and can be used for Ceph. Do not use the OS disk (here `nvme0n2`).
-
-### Wipe Drives (if needed)
-
-If drives have existing partitions or filesystems, wipe them:
-
-```bash
-# WARNING: This destroys all data on the drive!
-sudo wipefs -a /dev/nvme0n1
-sudo wipefs -a /dev/nvme1n1
-```
-
----
-
-## STEP 2 - Install Rook-Ceph Operator
-
-Run from a **control plane node**:
-
-### Add Rook Helm Repository
+Run these commands from a control-plane node with Helm 4.2.4 or newer:
 
 ```bash
 helm repo add rook-release https://charts.rook.io/release
 helm repo update
-```
+kubectl create namespace rook-ceph --dry-run=client --output yaml | kubectl apply -f -
 
-### Create Rook-Ceph Namespace
-
-```bash
-kubectl create namespace rook-ceph
-```
-
-### Install Operator
-
-**Standard installation (default kubelet path `/var/lib/kubelet`):**
-
-```bash
-helm install rook-ceph-operator rook-release/rook-ceph \
+helm upgrade --install rook-ceph-operator rook-release/rook-ceph \
   --namespace rook-ceph \
-  --version 1.18.7 \
+  --version 1.19.10 \
   --wait \
   --timeout 10m
 ```
 
-**Custom kubelet path (if you configured a custom path in Kubernetes setup):**
+If kubelet uses a non-default root directory, add `--set csi.kubeletDirPath=/your/kubelet/root` to the Helm command. K3s uses `/var/lib/kubelet` unless you changed it outside the Provider Playbook.
 
-If you configured a custom kubelet directory (e.g., `/data/kubelet`), you need to set the CSI kubelet directory:
-
-```bash
-helm install rook-ceph-operator rook-release/rook-ceph \
-  --namespace rook-ceph \
-  --version 1.18.7 \
-  --set csi.kubeletDirPath="/data/kubelet" \
-  --wait \
-  --timeout 10m
-```
-
-### Verify Operator
+Verify the operator:
 
 ```bash
-kubectl -n rook-ceph get pods
+kubectl --namespace rook-ceph rollout status deployment/rook-ceph-operator
+kubectl --namespace rook-ceph get pods
 ```
 
-**Expected output:**
+## 3. Define the Ceph cluster
 
-```
-NAME                                 READY   STATUS    RESTARTS   AGE
-rook-ceph-operator-xxx               1/1     Running   0          2m
-rook-discover-xxx                    1/1     Running   0          2m
-rook-discover-yyy                    1/1     Running   0          2m
-```
+Create `rook-ceph-cluster.values.yml`. Replace the node names and example disk IDs with the exact values you recorded. The same disk must not appear under more than one node.
 
----
-
-## STEP 3 - Deploy Ceph Cluster
-
-### Create Cluster Configuration
-
-Create a file with your storage node and device information. The defaults below are for **NVMe** (`beta3`):
-
-```bash
-cat > rook-ceph-cluster.values.yml << 'EOF'
+```yaml
 operatorNamespace: rook-ceph
+clusterName: rook-ceph
+
+cephImage:
+  repository: quay.io/ceph/ceph
+  tag: v19.2.6-20260818
 
 configOverride: |
   [global]
@@ -168,24 +110,29 @@ configOverride: |
   osd_pool_default_min_size = 2
 
 cephClusterSpec:
-  dataDirHostPath: /var/lib/rook  # Change if using custom mount point
-  
+  dataDirHostPath: /var/lib/rook
+
   mon:
     count: 3
-  
+
   mgr:
     count: 2
 
   storage:
     useAllNodes: false
     useAllDevices: false
-    deviceFilter: "^nvme[0-9]+n1$"  # All NVMe namespaces nvme0n1, nvme1n1, …
     config:
-      osdsPerDevice: "2"            # NVMe default; use "1" for SATA/SAS SSD or HDD
+      osdsPerDevice: "1"
     nodes:
-    - name: "node1"                 # Replace with your actual node names
-    - name: "node2"
-    - name: "node3"
+      - name: "node1"
+        devices:
+          - name: "/dev/disk/by-id/nvme-example-node1"
+      - name: "node2"
+        devices:
+          - name: "/dev/disk/by-id/nvme-example-node2"
+      - name: "node3"
+        devices:
+          - name: "/dev/disk/by-id/nvme-example-node3"
 
 cephBlockPools:
   - name: akash-deployments
@@ -198,7 +145,7 @@ cephBlockPools:
         bulk: "true"
     storageClass:
       enabled: true
-      name: beta3                # NVMe storage class (default)
+      name: beta3
       isDefault: true
       reclaimPolicy: Delete
       allowVolumeExpansion: true
@@ -213,226 +160,131 @@ cephBlockPools:
         csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
         csi.storage.k8s.io/fstype: ext4
 
-# Do not create default Ceph file systems or object stores
 cephFileSystems:
 cephObjectStores:
 
-# Spawn rook-ceph-tools for troubleshooting
 toolbox:
   enabled: true
-EOF
 ```
 
-**Important Configuration:**
+For two storage hosts, change both default pool values and the block pool to size `2`, minimum size `1`, and failure domain `host`. For one storage host with at least two disks, use size `2`, minimum size `1`, and failure domain `osd`; set `mon.count` and `mgr.count` to `1` for a one-node cluster.
 
-- **dataDirHostPath:** Default is `/var/lib/rook`
-  - If using a custom mount point (e.g., RAID array at `/data`), change to `/data/rook`
-  - This directory stores Ceph monitor and manager data (not OSD data)
-- **deviceFilter:** Must match your data drives only (never the OS disk)
-  - **NVMe (default):** `"^nvme[0-9]+n1$"` — matches `nvme0n1`, `nvme1n1`, `nvme10n1`, etc.
-  - Do **not** use `"^nvme[01]n1"` — that is a single-character class (`0` or `1` only), so drives like `nvme2n1` are skipped and you get far fewer OSDs than expected
-  - SATA/SAS SSD or HDD: `"^sd[a-z]+$"` (adjust to your device names)
-- **osdsPerDevice:**
-  - NVMe (default): `"2"`
-  - HDD/SSD: `"1"`
-- **nodes:** Replace with your actual storage node names from `kubectl get nodes`
-- **storageClass name:**
-  - NVMe (default): `beta3`
-  - SSD: `beta2`
-  - HDD: `beta1`
+Use `beta2` for an all-SSD layout or `beta1` when any selected disk is an HDD.
 
-### Install Cluster
+## 4. Install and verify the cluster
+
+Review the file one final time. Installing the chart authorizes Rook to consume the listed disks.
 
 ```bash
-helm install rook-ceph-cluster rook-release/rook-ceph-cluster \
+helm upgrade --install rook-ceph-cluster rook-release/rook-ceph-cluster \
   --namespace rook-ceph \
-  --version 1.18.7 \
-  -f rook-ceph-cluster.values.yml
+  --version 1.19.10 \
+  --values rook-ceph-cluster.values.yml \
+  --wait \
+  --timeout 20m
 ```
 
-This will take **5-10 minutes** to deploy.
-
----
-
-## STEP 4 - Verify Ceph Cluster
-
-### Check Cluster Status
+Wait for the cluster and inspect its OSDs:
 
 ```bash
-kubectl -n rook-ceph get cephcluster
+kubectl --namespace rook-ceph get cephcluster rook-ceph
+kubectl --namespace rook-ceph get pods --selector app=rook-ceph-osd --output wide
+kubectl --namespace rook-ceph exec deployment/rook-ceph-tools -- ceph status
+kubectl --namespace rook-ceph exec deployment/rook-ceph-tools -- ceph osd tree
 ```
 
-**Expected output:**
+The expected OSD count equals the number of physical disks listed in the values file. Every expected OSD must be `up` and `in` before continuing.
 
-```
-NAME        DATADIRHOSTPATH   MONCOUNT   AGE   PHASE   MESSAGE                        HEALTH
-rook-ceph   /var/lib/rook     3          5m    Ready   Cluster created successfully   HEALTH_OK
-```
-
-Wait until `PHASE` is `Ready` and `HEALTH` is `HEALTH_OK`.
-
-### Check OSDs
+Label the selected StorageClass for Akash:
 
 ```bash
-kubectl -n rook-ceph get pods -l app=rook-ceph-osd
+kubectl label storageclass beta3 akash.network=true --overwrite
+kubectl get storageclass beta3 --show-labels
 ```
 
-You should see OSD pods running on your storage nodes. With `osdsPerDevice: "2"`, expect **two OSDs per NVMe drive** matched by `deviceFilter`.
+## 5. Prove volume provisioning
 
-### Check Ceph Status
+Create `test-pvc.yaml`:
 
-Use the Ceph toolbox to check cluster health:
-
-```bash
-kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph status
-```
-
-**Expected output:**
-
-```
-  cluster:
-    id:     a1b2c3d4-5678-90ab-cdef-1234567890ab
-    health: HEALTH_OK
- 
-  services:
-    mon: 3 daemons, quorum a,b,c
-    mgr: a(active), standbys: b
-    osd: 6 osds: 6 up, 6 in
-```
-
-(OSD count depends on how many NVMe drives match the filter × `osdsPerDevice`.)
-
-### Check Storage Class
-
-```bash
-kubectl get storageclass
-```
-
-**Expected output:**
-
-```
-NAME                 PROVISIONER                  RECLAIMPOLICY   VOLUMEBINDINGMODE   AGE
-beta3 (default)      rook-ceph.rbd.csi.ceph.com   Delete          Immediate           5m
-```
-
-### Label Storage Class for Akash
-
-Label your storage class so Akash can recognize it. With the defaults in this guide that is `beta3`:
-
-```bash
-kubectl label sc beta3 akash.network=true
-```
-
-If you used `beta1` or `beta2` instead, label that class name.
-
-Verify the label was applied:
-
-```bash
-kubectl get sc beta3 --show-labels
-```
-
-You should see `akash.network=true` in the labels.
-
----
-
-## STEP 5 - Test Persistent Storage
-
-Create a test PVC to verify storage is working:
-
-```bash
-cat > test-pvc.yaml << 'EOF'
+```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: test-pvc
+  name: ceph-test
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
   storageClassName: beta3
-EOF
+```
 
+Create and mount the claim:
+
+```bash
 kubectl apply -f test-pvc.yaml
+kubectl wait --for=jsonpath='{.status.phase}'=Bound persistentvolumeclaim/ceph-test --timeout=5m
+kubectl run ceph-test \
+  --image=busybox:1.36 \
+  --restart=Never \
+  --overrides='{"apiVersion":"v1","spec":{"containers":[{"name":"ceph-test","image":"busybox:1.36","command":["sh","-c","echo ok >/data/result && cat /data/result"],"volumeMounts":[{"name":"data","mountPath":"/data"}]}],"volumes":[{"name":"data","persistentVolumeClaim":{"claimName":"ceph-test"}}]}}'
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/ceph-test --timeout=5m
+kubectl logs ceph-test
 ```
 
-### Verify PVC
+The log must contain `ok`. Remove the test resources:
 
 ```bash
-kubectl get pvc test-pvc
+kubectl delete pod ceph-test
+kubectl delete persistentvolumeclaim ceph-test
 ```
 
-**Expected output:**
+Only advertise persistent storage after this end-to-end mount succeeds. During provider installation, add exactly the Akash-labelled class (`beta1`, `beta2`, or `beta3`) to the inventory operator and provider attributes.
 
-```
-NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-test-pvc   Bound    pvc-a1b2c3d4-5678-90ab-cdef-1234567890ab   1Gi        RWO            beta3          10s
-```
+## Existing-cluster upgrades
 
-Status should be `Bound`.
+Do not treat an existing Ceph cluster like a fresh install. Back up its configuration, review [Rook's upgrade procedure](https://rook.io/docs/rook/v1.19/Upgrade/rook-upgrade/), update Rook CRDs before the operator chart, and upgrade Rook before changing the Ceph image.
 
-### Cleanup
+Provider Playbook supports the direct Rook `1.18.x` to `1.19.10` path and Ceph `19.2.0` through `19.2.6`. It rejects downgrades and skipped Rook minor-version hops. Its upgrade workflow also performs the CephX AES256K daemon-key rotation required for the pinned Ceph release and waits for healthy daemons between phases.
 
-```bash
-kubectl delete pvc test-pvc
-```
-
----
+For a manually managed cluster, follow the [Rook CephX key-rotation procedure](https://rook.io/docs/rook/v1.19/Storage-Configuration/Advanced/cephx-key-rotation/) rather than copying only the fresh-install values above.
 
 ## Troubleshooting
 
-### Check Operator Logs
+### A selected disk does not create an OSD
+
+Check the OSD prepare jobs and verify the stable link still targets the intended whole disk:
 
 ```bash
-kubectl -n rook-ceph logs -l app=rook-ceph-operator
+kubectl --namespace rook-ceph get pods --selector app=rook-ceph-osd-prepare
+kubectl --namespace rook-ceph logs <osd-prepare-pod>
+readlink -f /dev/disk/by-id/<selected-disk-id>
+sudo wipefs --no-act /dev/<resolved-disk>
 ```
 
-### Check Ceph Logs
+Rook rejects disks that are partitioned, mounted, in LVM, or contain signatures. Do not switch to a wildcard filter to work around the rejection.
+
+### The cluster reports `HEALTH_WARN`
 
 ```bash
-kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph -s
-kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph osd tree
-kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph osd status
+kubectl --namespace rook-ceph exec deployment/rook-ceph-tools -- ceph health detail
 ```
 
-### Common Issues
+Initial placement-group warnings can resolve while the cluster converges. Investigate persistent warnings before installing the provider.
 
-**Fewer OSDs than expected (e.g. only ~6 when you have more NVMe drives):**
-- Check `deviceFilter`. `"^nvme[01]n1"` only matches `nvme0n1` and `nvme1n1`. Use `"^nvme[0-9]+n1$"` for all `nvmeXn1` data namespaces.
-- Confirm with `lsblk -f` which devices should be claimed, then `ceph osd tree` for what Ceph actually took.
+### A claim does not bind
 
-**OSDs not starting:**
-- Verify drives are unformatted: `lsblk -f`
-- Check deviceFilter matches your drives
-- Review OSD pod logs: `kubectl -n rook-ceph logs <osd-pod-name>`
+```bash
+kubectl describe persistentvolumeclaim ceph-test
+kubectl --namespace rook-ceph get pods --selector app=csi-rbdplugin-provisioner
+kubectl get storageclass beta3 --show-labels
+```
 
-**HEALTH_WARN:**
-- Check `ceph status` for specific warnings
-- Common warnings during initial setup are normal and will resolve
+After storage validation succeeds, continue to [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation).
 
-**No PVC binding:**
-- Verify storage class exists: `kubectl get sc`
-- Check CSI provisioner is running: `kubectl -n rook-ceph get pods -l app=csi-rbdplugin-provisioner`
+## Resources
 
----
-
-## Next Steps
-
-Your persistent storage is now ready!
-
-**→ [Provider Installation](/docs/providers/setup-and-installation/kubespray/provider-installation)** - Install the Akash provider
-
-**Optional enhancements:**
-- [Provider installation – STEP 9 (TLS)](/docs/providers/setup-and-installation/kubespray/provider-installation-prep#step-9---lets-encrypt-cert-manager-and-tls-secrets) - **Required** for all providers: cert-manager and Gateway TLS
-- [IP Leases](/docs/providers/setup-and-installation/kubespray/ip-leases) - Enable static IPs
-
-> **Note:** You'll need to configure storage classes in the inventory operator during provider installation to advertise persistent storage capabilities (`beta3` for this default NVMe setup). This is covered in the Provider Installation guide.
-
----
-
-## Additional Resources
-
-- [Rook Documentation](https://rook.io/docs/rook/latest-release/)
-- [Ceph Documentation](https://docs.ceph.com/)
-- [Storage Class Benchmarking Script](https://github.com/masonr/yet-another-bench-script)
+- [Rook-Ceph 1.19 documentation](https://rook.io/docs/rook/v1.19/)
+- [Ceph documentation](https://docs.ceph.com/)
+- [Provider Playbook version matrix](https://github.com/akash-network/provider-playbooks/blob/main/versions.yml)

--- a/src/content/Docs/providers/setup-and-installation/kubespray/provider-installation-prep/index.mdx
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/provider-installation-prep/index.mdx
@@ -22,10 +22,10 @@ Before starting, ensure you have:
 ### Required
 
 - **Kubernetes cluster** deployed and verified
-- **Domain name** that you control (e.g., `provider.example.com`)
+- **Base domain** that you control (for example, `example.com`; the provider endpoint becomes `provider.example.com`)
 - **Akash wallet** with:
   - **Provider bid deposit** is in **AKT** (0.5 AKT); keep AKT for gas. Recommended balance for multiple bids.
-  - Funded account ([Fund Your Account](/docs/developers/deployment/cli/installation-guide/#fund-your-account))
+  - A funded address in the active `akt` mainnet keyring context
 
 ### Optional (if configured)
 
@@ -37,20 +37,26 @@ Before starting, ensure you have:
 ## STEP 1 - Prepare Provider Wallet
 
 > **Don't have an Akash wallet yet?**
-> - [Install Akash CLI](/docs/developers/deployment/cli/installation-guide/)
-> - [Create an Account](/docs/developers/deployment/cli/installation-guide/#create-an-account)
-> - [Fund Your Account](/docs/developers/deployment/cli/installation-guide/#fund-your-account)
+>
+> - [Install the `akt` CLI](/docs/developers/deployment/akt/installation/)
+> - [Create or recover a key](/docs/developers/deployment/akt/configuration/#key-management)
+> - Select a mainnet keyring context and fund its Akash address before installing the provider
 
 ### Export Wallet Key
 
 On your local machine (where you created your Akash wallet):
 
 ```bash
+umask 077
+
 # Export your private key
-provider-services keys export <your-key-name>
+akt context keys export <your-key-name> > key.pem
+
+# Record its address for the control-plane host
+akt context keys show <your-key-name> --address > account-address.txt
 ```
 
-You'll be prompted for your keyring passphrase. The output will look like:
+`akt` prompts for the keyring password and an export password. The resulting `key.pem` contains an armored private key:
 
 ```
 -----BEGIN TENDERMINT PRIVATE KEY-----
@@ -62,14 +68,12 @@ type: secp256k1
 -----END TENDERMINT PRIVATE KEY-----
 ```
 
-Save this output to a file called `key.pem`.
+### Record the export password
 
-### Create Key Secret
-
-Create a password for your key:
+Write the export password you selected above to `key-pass.txt`. This is not the keyring password:
 
 ```bash
-echo "your-secure-password" > key-pass.txt
+printf '%s' 'your-export-password' > key-pass.txt
 ```
 
 ---
@@ -79,15 +83,24 @@ echo "your-secure-password" > key-pass.txt
 SSH into your Kubernetes control plane node and create the provider directory:
 
 ```bash
-mkdir -p /root/provider
+install -d -m 700 /root/provider
 cd /root/provider
+umask 077
 ```
 
 ### Upload Files
 
 Upload the following files to `/root/provider/`:
+
 - `key.pem` (your private key)
-- `key-pass.txt` (your key password)
+- `key-pass.txt` (the private-key export password)
+- `account-address.txt` (the provider's Akash address)
+
+Protect them after upload:
+
+```bash
+chmod 600 /root/provider/key.pem /root/provider/key-pass.txt /root/provider/account-address.txt
+```
 
 ### Encode Secrets
 
@@ -98,8 +111,8 @@ KEY_SECRET=$(cat /root/provider/key.pem | openssl base64 -A)
 # Base64 encode the password
 KEY_PASSWORD=$(cat /root/provider/key-pass.txt | openssl base64 -A)
 
-# Get your provider address
-ACCOUNT_ADDRESS=$(provider-services keys show <your-key-name> -a)
+# Read the provider address exported on the local machine
+ACCOUNT_ADDRESS=$(cat /root/provider/account-address.txt)
 ```
 
 ---
@@ -110,8 +123,8 @@ ACCOUNT_ADDRESS=$(provider-services keys show <your-key-name> -a)
 
 ```bash
 # Download Helm
-wget https://get.helm.sh/helm-v4.0.1-linux-amd64.tar.gz
-tar -zxvf helm-v4.0.1-linux-amd64.tar.gz
+wget https://get.helm.sh/helm-v4.2.4-linux-amd64.tar.gz
+tar -zxvf helm-v4.2.4-linux-amd64.tar.gz
 install linux-amd64/helm /usr/local/bin/helm
 
 # Verify installation
@@ -134,8 +147,12 @@ Create all required namespaces:
 ```bash
 kubectl create namespace akash-services
 kubectl create namespace lease
+kubectl create namespace akash-gateway
 kubectl label namespace akash-services akash.network=true
+kubectl label namespace akash-services akash.network/name=akash-services
 kubectl label namespace lease akash.network=true
+kubectl label namespace akash-gateway akash.network=true
+kubectl label namespace akash-gateway akash.network/name=akash-gateway
 ```
 
 ---
@@ -149,8 +166,9 @@ kubectl label namespace lease akash.network=true
 The default installation uses blockchain snapshots for fast synchronization.
 
 ```bash
-helm install akash-node akash/akash-node \
-  -n akash-services
+helm upgrade --install akash-node akash/akash-node \
+  --namespace akash-services \
+  --version 18.0.0
 ```
 
 ### Verify Node is Running
@@ -178,7 +196,8 @@ akash-node-1-0   1/1     Running   0          2m
 
 ```bash
 cd /root/provider
-curl -s https://raw.githubusercontent.com/akash-network/helm-charts/main/charts/akash-provider/scripts/price_script_generic.sh > price_script.sh
+curl -fsSLo price_script.sh \
+  https://raw.githubusercontent.com/akash-network/helm-charts/provider-19.0.2/charts/akash-provider/scripts/price_script_generic.sh
 chmod +x price_script.sh
 ```
 
@@ -187,12 +206,12 @@ chmod +x price_script.sh
 Replace the values with your actual configuration:
 
 ```bash
-cat > /root/provider/provider.yaml << 'EOF'
+cat > /root/provider/provider.yaml << EOF
 ---
 from: "$ACCOUNT_ADDRESS"
 key: "$KEY_SECRET"
 keysecret: "$KEY_PASSWORD"
-domain: "provider.example.com"
+domain: "example.com"
 node: "http://akash-node-1:26657"
 withdrawalperiod: 12h
 chainid: "akashnet-2"
@@ -209,12 +228,28 @@ attributes:
     value: contact@example.com
   - key: discord-username
     value: your_discord_username
+  - key: website
+    value: https://example.com
+  - key: status-page
+    value: https://status.example.com
   - key: country
     value: US
   - key: city
-    value: "San Francisco"
+    value: SFO
+  - key: timezone
+    value: utc-8
   - key: location-type
     value: datacenter
+  - key: hosting-provider
+    value: your_facility
+  - key: network-provider
+    value: your_network
+  - key: capabilities/ip-lease
+    value: "false"
+  - key: feat-endpoint-ip
+    value: "false"
+  - key: feat-endpoint-custom-domain
+    value: true
   - key: feat-persistent-storage
     value: false
   - key: feat-shm
@@ -270,22 +305,22 @@ attributes:
 **Example for beta3 (NVMe) storage class:**
 
 ```yaml
-  - key: capabilities/storage/1/class
-    value: beta3
-  - key: capabilities/storage/1/persistent
-    value: "true"
+- key: capabilities/storage/1/class
+  value: beta3
+- key: capabilities/storage/1/persistent
+  value: "true"
 ```
 
 **Example for beta2 (SSD) storage class:**
 
 ```yaml
-  - key: capabilities/storage/1/class
-    value: beta2
-  - key: capabilities/storage/1/persistent
-    value: "true"
+- key: capabilities/storage/1/class
+  value: beta2
+- key: capabilities/storage/1/persistent
+  value: "true"
 ```
 
-> **Important:** You can only advertise **one storage class** per provider. Match Rook-Ceph: **`beta3` (NVMe) is the default** in the Persistent Storage guide; use `beta2` (SSD) or `beta1` (HDD) only if you configured that instead.
+> **Important:** You can only advertise **one storage class** per provider. Match the class to the storage media you actually configured: `beta3` for NVMe, `beta2` for SSD, or `beta1` for HDD. The Persistent Storage guide uses `beta3` only because its worked example uses NVMe disks.
 
 ---
 
@@ -296,27 +331,31 @@ If you configured GPU support, add GPU attributes to your `provider.yaml`:
 ```yaml
 attributes:
   # ... existing attributes ...
+  - key: capabilities/gpu
+    value: nvidia
+  - key: cuda
+    value: "13.0"
   - key: capabilities/gpu/vendor/nvidia/model/<model>
     value: "true"
   - key: capabilities/gpu/vendor/nvidia/model/<model>/ram/<ram>
     value: "true"
   - key: capabilities/gpu/vendor/nvidia/model/<model>/interface/<interface>
     value: "true"
-  - key: capabilities/gpu/vendor/nvidia/model/<model>/interface/<interface>/ram/<ram>
+  - key: capabilities/gpu/vendor/nvidia/model/<model>/ram/<ram>/interface/<interface>
     value: "true"
 ```
 
 **Example for NVIDIA RTX 4090:**
 
 ```yaml
-  - key: capabilities/gpu/vendor/nvidia/model/rtx4090
-    value: "true"
-  - key: capabilities/gpu/vendor/nvidia/model/rtx4090/ram/24Gi
-    value: "true"
-  - key: capabilities/gpu/vendor/nvidia/model/rtx4090/interface/pcie
-    value: "true"
-  - key: capabilities/gpu/vendor/nvidia/model/rtx4090/interface/pcie/ram/24Gi
-    value: "true"
+- key: capabilities/gpu/vendor/nvidia/model/rtx4090
+  value: "true"
+- key: capabilities/gpu/vendor/nvidia/model/rtx4090/ram/24Gi
+  value: "true"
+- key: capabilities/gpu/vendor/nvidia/model/rtx4090/interface/pcie
+  value: "true"
+- key: capabilities/gpu/vendor/nvidia/model/rtx4090/ram/24Gi/interface/pcie
+  value: "true"
 ```
 
 > **Note:** Model names should be lowercase with no spaces. List each GPU model you're offering.
@@ -326,13 +365,13 @@ attributes:
 If you completed [Part 2 — InfiniBand / RDMA](/docs/providers/setup-and-installation/kubespray/gpu-support#part-2--infiniband--rdma-optional), advertise interconnect so tenants can match multi-node NCCL jobs:
 
 ```yaml
-  - key: capabilities/gpu-interconnect
-    value: "true"
-  - key: capabilities/gpu-interconnect/fabric/infiniband
-    value: "true"
-  # Or RoCE instead of (or in addition to) InfiniBand:
-  # - key: capabilities/gpu-interconnect/fabric/roce
-  #   value: "true"
+- key: capabilities/gpu-interconnect
+  value: "true"
+- key: capabilities/gpu-interconnect/fabric/infiniband
+  value: "true"
+# Or RoCE instead of (or in addition to) InfiniBand:
+# - key: capabilities/gpu-interconnect/fabric/roce
+#   value: "true"
 ```
 
 Omit these keys if your nodes have no InfiniBand/RoCE hardware. Full details: [Provider Attributes — GPU Interconnect](/docs/providers/operations/provider-attributes/#gpu-interconnect-infiniband--roce).
@@ -348,7 +387,7 @@ Here's a full example showing GPU, persistent storage, and all optional attribut
 from: "akash1..."
 key: "LS0tLS1CRUdJTi..."
 keysecret: "eHJiajdSS..."
-domain: "provider.example.com"
+domain: "example.com"
 node: "http://akash-node-1:26657"
 withdrawalperiod: 12h
 chainid: "akashnet-2"
@@ -360,7 +399,9 @@ attributes:
   - key: country
     value: US
   - key: city
-    value: "San Francisco"
+    value: SFO
+  - key: timezone
+    value: utc-8
   - key: location-type
     value: datacenter
 
@@ -375,6 +416,12 @@ attributes:
     value: contact@example.com
   - key: discord-username
     value: your_discord_username
+  - key: website
+    value: https://example.com
+  - key: status-page
+    value: https://status.example.com
+  - key: hosting-provider
+    value: your_facility
 
   # CPU & memory
   - key: capabilities/cpu
@@ -389,6 +436,14 @@ attributes:
     value: 10000
   - key: network-speed-down
     value: 10000
+  - key: network-provider
+    value: your_network
+  - key: capabilities/ip-lease
+    value: "false"
+  - key: feat-endpoint-ip
+    value: "false"
+  - key: feat-endpoint-custom-domain
+    value: true
 
   # GPU (if you have GPUs)
   - key: capabilities/gpu
@@ -399,7 +454,7 @@ attributes:
     value: "true"
   - key: capabilities/gpu/vendor/nvidia/model/h100/interface/sxm
     value: "true"
-  - key: capabilities/gpu/vendor/nvidia/model/h100/interface/sxm/ram/80Gi
+  - key: capabilities/gpu/vendor/nvidia/model/h100/ram/80Gi/interface/sxm
     value: "true"
   - key: cuda
     value: "13.0"
@@ -442,7 +497,6 @@ price_target_gpu_mappings: "h100=840,*=840"
 
 ---
 
-
 ## STEP 7 - Configure DNS
 
 ### Configure at Your DNS Provider
@@ -450,6 +504,7 @@ price_target_gpu_mappings: "h100=840,*=840"
 Log into your DNS provider (Cloudflare, GoDaddy, Route53, etc.) and create the following DNS records:
 
 **1. Provider A Record:**
+
 ```
 Type: A
 Name: provider (or your subdomain)
@@ -458,17 +513,19 @@ TTL: 3600 (or Auto)
 ```
 
 **2. Wildcard Ingress A Record:**
+
 ```
 Type: A
-Name: *.ingress.provider (or *.ingress.your-subdomain)
+Name: *.ingress
 Value: <your-provider-public-ip>
 TTL: 3600 (or Auto)
 ```
 
 **Example:**
+
 ```
-provider.example.com           →  203.0.113.45
-*.ingress.provider.example.com →  203.0.113.45
+provider.example.com  →  203.0.113.45
+*.ingress.example.com →  203.0.113.45
 ```
 
 ### Verify DNS Propagation
@@ -480,7 +537,7 @@ After configuring DNS, verify both records resolve correctly:
 dig provider.example.com +short
 
 # Check wildcard ingress domain
-dig test.ingress.provider.example.com +short
+dig test.ingress.example.com +short
 ```
 
 Both should return your provider's public IP.
@@ -488,7 +545,6 @@ Both should return your provider's public IP.
 > **Note:** DNS propagation can take a few minutes. Wait until both records resolve before proceeding.
 
 ---
-
 
 ## STEP 8 - Install Gateway API and NGINX Gateway Fabric
 
@@ -893,6 +949,7 @@ kubectl -n cert-manager get secret cloudflare-api-token-secret -o yaml
 ```
 
 Check token has correct permissions in Cloudflare dashboard:
+
 - **Zone - DNS - Edit**
 - **Zone - Zone - Read**
 - Zone Resources: All Zones
@@ -908,6 +965,7 @@ kubectl -n cert-manager get secret clouddns-gcp-dns01-solver-sa -o yaml
 ```
 
 Check service account has DNS admin permissions in GCP:
+
 - `dns.resourceRecordSets.*`
 - `dns.changes.*`
 - `dns.managedZones.list`
@@ -931,7 +989,6 @@ Wait a minute, then test HTTPS again.
 
 - [Cert-manager](https://cert-manager.io/docs/)
 - [Let's Encrypt](https://letsencrypt.org/)
-
 
 ---
 

--- a/src/content/Docs/providers/setup-and-installation/kubespray/provider-installation/index.mdx
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/provider-installation/index.mdx
@@ -19,7 +19,11 @@ The [akash-gateway](https://github.com/akash-network/helm-charts/tree/main/chart
 
 ```bash
 cd /root/provider
-helm install akash-gateway akash/akash-gateway -n akash-gateway --create-namespace -f provider.yaml
+helm upgrade --install akash-gateway akash/akash-gateway \
+  --namespace akash-gateway \
+  --create-namespace \
+  --version 1.2.1 \
+  --values provider.yaml
 ```
 
 If you are not using a file yet, you can use `--set "domain=yourdomain.com"` once; a single `provider.yaml` is **recommended** so the domain is identical for the [provider install (STEP 3)](#step-3---install-provider).
@@ -40,8 +44,9 @@ kubectl -n akash-services get tcproutes
 ### Install Hostname Operator
 
 ```bash
-helm install akash-hostname-operator akash/akash-hostname-operator \
-  -n akash-services
+helm upgrade --install akash-hostname-operator akash/akash-hostname-operator \
+  --namespace akash-services \
+  --version 19.0.2
 ```
 
 ### Install Inventory Operator
@@ -49,8 +54,9 @@ helm install akash-hostname-operator akash/akash-hostname-operator \
 **Without persistent storage:**
 
 ```bash
-helm install inventory-operator akash/akash-inventory-operator \
-  -n akash-services \
+helm upgrade --install inventory-operator akash/akash-inventory-operator \
+  --namespace akash-services \
+  --version 19.0.2 \
   --set inventoryConfig.cluster_storage[0]=default \
   --set inventoryConfig.cluster_storage[1]=ram
 ```
@@ -58,14 +64,16 @@ helm install inventory-operator akash/akash-inventory-operator \
 **With persistent storage (adjust beta3 to your storage class):**
 
 ```bash
-helm install inventory-operator akash/akash-inventory-operator \
-  -n akash-services \
+helm upgrade --install inventory-operator akash/akash-inventory-operator \
+  --namespace akash-services \
+  --version 19.0.2 \
   --set inventoryConfig.cluster_storage[0]=default \
   --set inventoryConfig.cluster_storage[1]=beta3 \
   --set inventoryConfig.cluster_storage[2]=ram
 ```
 
-**Note:** 
+**Note:**
+
 - Index 0 is always **default** (ephemeral storage)
 - Index 1 is **ram** (SHM/shared memory) if no persistent storage, or your persistent storage class (**beta1**/**beta2**/**beta3**)
 - Index 2 is **ram** (SHM/shared memory) if you have persistent storage
@@ -74,20 +82,20 @@ helm install inventory-operator akash/akash-inventory-operator \
 ### Apply Provider CRDs
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/akash-network/provider/main/pkg/apis/akash.network/crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/akash-network/provider/v0.16.2/pkg/apis/akash.network/crd.yaml
 ```
 
 ---
-
 
 ## STEP 3 - Install Provider
 
 ```bash
 cd /root/provider
 
-helm install akash-provider akash/provider \
-  -n akash-services \
-  -f provider.yaml \
+helm upgrade --install akash-provider akash/provider \
+  --namespace akash-services \
+  --version 19.0.2 \
+  --values provider.yaml \
   --set bidpricescript="$(cat price_script.sh | openssl base64 -A)"
 ```
 
@@ -131,9 +139,10 @@ The Gateway should show `PROGRAMMED: True`. TCPRoutes `akash-provider-8443`, `ak
 
 ### Check Provider Status
 
+Run this back on the local wallet machine, where `akt` has the mainnet context from the preparation steps:
+
 ```bash
-provider-services query provider get $ACCOUNT_ADDRESS \
-  --node https://rpc.akashnet.net:443
+akt query provider "$(cat account-address.txt)" --output yaml
 ```
 
 **Expected output:**
@@ -168,6 +177,7 @@ Look for messages indicating the provider is bidding on deployments.
 Ensure these ports are open on your provider's public IP:
 
 **Required:**
+
 - `80/tcp` - HTTP
 - `443/tcp` - HTTPS
 - `8443/tcp` - Provider endpoint
@@ -176,6 +186,7 @@ Ensure these ports are open on your provider's public IP:
 - `30000-32767/tcp` - Kubernetes NodePort range
 
 **Optional (if using external access):**
+
 - `6443/tcp` - Kubernetes API
 
 Test connectivity:
@@ -257,20 +268,24 @@ The script runs every 5 minutes to clean up stuck ReplicaSets.
 
 ## Next Steps
 
-Your provider is now running! 
+Your provider is now running!
 
 **Verify your provider:**
+
 - **→ [Provider Verification](/docs/providers/operations/provider-verification/)** - Verify your provider is working correctly
 
 **Quick health checks:**
+
 - Monitor provider status: `kubectl -n akash-services get pods`
 - Check bids: `kubectl -n akash-services logs akash-provider-0 | grep bid`
 - Watch for leases: `kubectl -n lease get pods`
 
 **Optional follow-ups:**
+
 - [IP Leases](/docs/providers/setup-and-installation/kubespray/ip-leases) — static IPs for deployments
 
 **Provider Resources:**
+
 - [Provider Calculator](https://akash.network/pricing/provider-calculator/) - Estimate earnings (provider payouts are in ACT)
 - [Provider Operations](/docs/providers/operations/) - Lease management, monitoring, and maintenance
 - [Akash Discord](https://discord.akash.network) - Join the provider community
@@ -291,6 +306,7 @@ cd /root/provider
 
 helm upgrade akash-provider akash/provider \
   -n akash-services \
+  --version 19.0.2 \
   -f provider.yaml \
   --set bidpricescript="$(cat price_script.sh | openssl base64 -A)"
 ```

--- a/src/content/Docs/providers/setup-and-installation/kubespray/reclamation/index.md
+++ b/src/content/Docs/providers/setup-and-installation/kubespray/reclamation/index.md
@@ -15,11 +15,12 @@ By default, providers do not offer reclamation. Reclamation is opt-in via config
 
 ## Prerequisites
 
-- `provider-services` **v0.13.0** or later
+- Akash provider `v0.16.2` or later
+- The unified [`akt` CLI](/docs/developers/deployment/akt) in a mainnet keyring context for queries and close transactions
 
 ## Configuration
 
-The reclamation window is set via the `--reclamation-window` flag on `provider-services run`, or equivalently via the `AKASH_RECLAMATION_WINDOW` environment variable.
+Set the reclamation window with the provider chart's `reclamationWindow` value. The chart injects the corresponding `AKASH_RECLAMATION_WINDOW` environment variable into the provider StatefulSet.
 
 Accepted values are Go-style duration strings:
 
@@ -93,10 +94,9 @@ If the provider's configured window is shorter than the order's required minimum
 You can confirm a successful bid's reclamation window on chain:
 
 ```bash
-akash query market bid get \
-    --owner <tenant-address> \
-    --dseq <dseq> --gseq 1 --oseq 1 \
-    --provider <your-provider-address>
+akt query market bid \
+    <tenant-address>/<dseq>/1/1/<your-provider-address> \
+    --output yaml
 ```
 
 The `reclamation_window` field on the bid will reflect the configured value.
@@ -119,18 +119,9 @@ The provider will resume default behavior: no reclamation offered on bids, and o
 
 ## Initiating reclamation
 
-When you need to reclaim resources from an active lease, submit a `MsgLeaseStartReclaim` from the provider key:
+When you need to reclaim resources from an active lease, submit a `MsgLeaseStartReclaim` from the provider key.
 
-```bash
-provider-services tx market bid start-reclaim \
-    --from <provider-key> \
-    --owner <tenant-address> \
-    --dseq <dseq> --gseq 1 --oseq 1 \
-    --provider <your-provider-address> \
-    --reason <reason-code> \
-    --chain-id <chain-id> \
-    --node <rpc-endpoint>
-```
+`akt` v0.1.1 does not yet expose the start-reclaim transaction. Do not substitute the removed legacy `provider-services` CLI examples. Until `akt` adds this command, enable reclamation only when your provider automation has a separately supported way to submit and audit `MsgLeaseStartReclaim`.
 
 The `--reason` flag accepts a numeric code in the range 10000–19999:
 
@@ -144,14 +135,12 @@ Choose the code that most accurately reflects why you're reclaiming. The reason 
 After the reclamation window elapses, close the bid to terminate the lease:
 
 ```bash
-provider-services tx market bid close \
+akt tx market bid close \
     --from <provider-key> \
     --owner <tenant-address> \
     --dseq <dseq> --gseq 1 --oseq 1 \
-    --provider <your-provider-address> \
     --reason <reason-code> \
-    --chain-id <chain-id> \
-    --node <rpc-endpoint>
+    --yes
 ```
 
 Closing before the deadline is rejected by the chain with `reclamation window has not elapsed`.

--- a/src/content/Docs/providers/setup-and-installation/provider-playbook/index.md
+++ b/src/content/Docs/providers/setup-and-installation/provider-playbook/index.md
@@ -4,376 +4,250 @@ tags: ["Provider Playbook", "Automation", "Ansible", "Setup"]
 weight: 1
 title: "Provider Playbook - Automated Setup"
 linkTitle: "Provider Playbook"
-description: "Automated provider setup using Ansible playbooks"
+description: "Build or extend an Akash provider with the guided Ansible installer"
 ---
 
-**The fastest way to set up an Akash provider using automated Ansible playbooks.**
+The Provider Playbook is the recommended guided installer for self-managed Akash providers. It can build Kubernetes with Kubespray or K3s, or add provider components to an existing cluster.
 
-The Provider Playbook features an interactive setup script that guides you through the entire process, automating Kubernetes installation, provider deployment, and configuration.
+The terminal wizard validates access before making changes, detects host capabilities over SSH, recommends safe defaults, shows a redacted review, and installs only the components you select.
 
- **Setup Time:** ~1 hour
+## Before you start
 
----
+The installer supports Ubuntu 24.04 LTS on x86-64 hosts. Review the [provider hardware requirements](/docs/providers/getting-started/hardware-requirements) before provisioning nodes.
 
-## Why Provider Playbook?
+You also need:
 
-### **Advantages**
-- **Interactive wizard** - Guides you through every step
-- **Automated setup** - Handles all the heavy lifting
-- **Multiple Kubernetes options** - Choose Kubespray (production) or K3s (lightweight)
-- **Flexible configuration** - Select only what you need
-- **Standardized deployment** - Consistent, repeatable process
-- **Infrastructure as Code** - All configurations versioned
+- Root access on the machine where you run the installer.
+- SSH console or out-of-band access to every node so you can authorize an SSH public key.
+- Passwordless `sudo` for every non-root SSH user. Password-based SSH is not supported.
+- A domain you control and the ability to create its DNS records.
+- A funded Akash wallet, or funds to transfer to a wallet created by the wizard.
+- For GPU installation, clean NVIDIA hosts without a preinstalled driver, CUDA driver package, Container Toolkit, or legacy NVIDIA device-plugin Helm release.
+- For Rook-Ceph, at least two dedicated, empty physical disks across the cluster. Three storage hosts are recommended for production availability.
 
-###  Considerations
-- Requires command-line comfort
-- SSH access to all nodes required
-- Still requires Linux/networking understanding
+The reachable SSH address, user, and port for each node are the only host details you must know in advance. Location, CPU, memory, GPUs, network addresses, and eligible Ceph disks are detected after SSH access succeeds.
 
----
+## Install
 
-## What It Automates
-
-The interactive script handles:
-- **Prerequisite installation (Python, Ansible, tools)**
-- **Kubernetes cluster deployment (Kubespray or K3s)**
-- **Wallet setup (create new or import existing)**
-- **GPU detection and NVIDIA driver installation**
-- **Storage configuration (Rook-Ceph for persistent storage)**
-- **Provider software installation and configuration**
-- **OS optimizations and cron jobs**
-- **Tailscale VPN setup (optional)**
-- **SSH key distribution across nodes**
-
----
-
-## Prerequisites
-
-### System Requirements
-- **Ubuntu 24.04 LTS Server** (officially supported)
-- **Root or sudo access** on all nodes
-- **SSH access** to all nodes
-
-### Hardware Requirements
-See [Hardware Requirements](/docs/providers/getting-started/hardware-requirements) for detailed specifications.
-
-### Information You'll Need
-
-Have this ready before starting:
-
-**1. Provider Details:**
-- Provider domain name (e.g., `provider.example.com`)
-- `location-region` — UN geoscheme region (e.g., `na-us-west`)
-- Organization name
-- Contact email
-- Organization website
-
-**2. Node Information:**
-- Number of nodes in your cluster
-- IP addresses for each node
-- SSH credentials (username/port) for each node
-
-**3. Wallet (one of the following):**
-- Create a new wallet during setup (recommended)
-- Existing wallet key file to import
-- Existing wallet mnemonic phrase
-- Existing AKT address with base64 encoded key
-
-**4. Storage Configuration (if using persistent storage):**
-- Storage device names (e.g., `/dev/sdb`, `/dev/nvme0n1`)
-- Number of OSDs per device
-- Storage device type (HDD/SSD/NVMe)
-- Which nodes will provide storage
-
-**5. Tailscale (optional):**
-- Tailscale auth key for secure remote access
-
----
-
-## Installation
-
-### Step 1: SSH into Your First Node
-
-```bash
-ssh user@node1-ip-address
-```
-
-The setup script should be run from your first node (node1) which will become part of your cluster.
-
-### Step 2: Clone the Repository
+Connect to the first node, clone the repository, and run the wizard as root:
 
 ```bash
 git clone https://github.com/akash-network/provider-playbooks.git
 cd provider-playbooks
+sudo ./scripts/setup_provider.sh
 ```
 
-### Step 3: Run the Setup Script
+Successful prerequisite commands keep package-manager output hidden. If a command fails, the wizard prints its captured output with the failing step.
+
+## Installer workflow
+
+### 1. Choose the Kubernetes foundation
+
+| Mode             | Use it when                                       | Behavior                                                                |
+| ---------------- | ------------------------------------------------- | ----------------------------------------------------------------------- |
+| Kubespray        | You want a production-oriented Kubernetes cluster | Downloads the pinned Kubespray release only for this mode               |
+| K3s              | You want a lean Kubernetes installation           | Uses the playbook's K3s role and never downloads Kubespray              |
+| Existing cluster | Kubernetes is already installed                   | Leaves the distribution untouched and installs only selected components |
+
+For clusters built by the wizard, every control-plane node is also a worker:
+
+| Node count | Control planes              | Workers               |
+| ---------: | --------------------------- | --------------------- |
+|          1 | `node1`                     | `node1`               |
+|          2 | `node1`                     | `node1`, `node2`      |
+|  3 or more | `node1`, or `node1`–`node3` | Every configured node |
+
+Kubespray prompts for kubelet and containerd data directories. K3s keeps kubelet data at `/var/lib/kubelet` and prompts only for the K3s data directory, which defaults to `/var/lib/rancher/k3s`.
+
+When using an existing cluster, the first entered host must map to a control-plane node where `sudo kubectl` works. The wizard maps each SSH host to a unique Kubernetes node and does not ask Kubernetes to advertise different node addresses.
+
+### 2. Select components
+
+The wizard can install:
+
+- Provider OS tuning and maintenance jobs.
+- NVIDIA GPU Operator on detected GPU nodes.
+- Rook-Ceph persistent storage.
+- The Akash node, gateway, provider, hostname operator, and inventory operator.
+- Optional Tailscale access.
+
+OS tuning and the provider stack are selected by default. GPU, Rook-Ceph, and Tailscale are opt in.
+
+### 3. Establish SSH access
+
+Enter a reachable IPv4 address, SSH user, and SSH port for each node. The wizard then selects a compatible local key or creates a dedicated Ed25519 key and displays the public key and target users.
+
+Add that public key to each target user's `~/.ssh/authorized_keys`, then continue. The wizard loops until every host accepts key-only SSH and every non-root user can run non-interactive `sudo`.
+
+For a new Kubespray or K3s cluster, private and public addresses are detected over the verified SSH connection. When both are available, the wizard recommends private addresses for Kubernetes inter-node traffic. SSH continues to use the reachable address you entered.
+
+### 4. Detect provider capabilities
+
+Discovery runs over SSH after access validation:
+
+- The first node's public egress address is used to suggest country, city code, UTC offset, and a valid Akash `location-region`. If lookup fails or you decline the result, a guided region picker builds the attributes.
+- `lscpu` and firmware data provide CPU vendor, architecture, memory generation, and ECC. The wizard asks only for values the host does not expose or that you decline.
+- PCI display devices are matched against a pinned Akash GPU database. The wizard derives the provider's GPU model, memory, interface, CUDA, and Fabric Manager settings. SXM GPUs enable Fabric Manager automatically.
+- If Rook-Ceph is selected, every configured host is scanned read-only for eligible whole disks.
+
+### 5. Configure the provider
+
+The wizard collects the base domain without a `provider.` prefix, organization and contact attributes, network attributes, and TLS method. Production TLS can use Cloudflare or Google Cloud DNS-01; a self-signed certificate is available for bootstrap and testing.
+
+Wallet creation, recovery, lookup, and export use only the unified [`akt` CLI](/docs/developers/deployment/akt). The installer uses a dedicated context named `provider`, creating it for mainnet when it is absent instead of launching `akt`'s general first-run network picker. If that context already exists, verify that it points to mainnet before continuing.
+
+Wallet options are:
+
+- Use an existing key from the provider context.
+- Create a new key and display its recovery mnemonic.
+- Recover a key from a mnemonic.
+- Supply an address and pre-encoded provider secrets.
+
+The keyring password is collected once and reused only for the current wallet operation. A separate provider export password is generated automatically and stored only in the protected inventory. If a requested key name already exists, the wizard offers to use it or enter another name.
+
+### 6. Review and deploy
+
+Before writing generated inventory or deploying roles, the wizard displays a redacted installation profile with hosts, topology, components, provider attributes, and storage choices. After confirmation, it generates the protected inventory and starts deployment.
+
+The component order is:
+
+1. Kubernetes foundation and cluster verification.
+2. NVIDIA GPU Operator.
+3. Rook-Ceph storage.
+4. Akash provider stack.
+
+OS preparation runs before the optional infrastructure components. Cluster-scoped Helm operations run once from the first control-plane host; they are not repeated on every node.
+
+## Ceph disk discovery and recommendations
+
+Storage discovery never wipes or modifies a disk. It excludes a device when it is:
+
+- Read-only, removable, or smaller than 5 GiB.
+- Partitioned, mapped, mounted, or used as swap.
+- Marked with filesystem, RAID, LVM, or Ceph signatures.
+- Held by another block device.
+- Missing a stable `/dev/disk/by-id` identity.
+
+The recommendation prioritizes three storage hosts, then two storage hosts, then two physical disks on one host. It prefers the fastest homogeneous media tier that preserves the best available topology. If mixed media are selected, the provider advertises the slowest selected tier:
+
+| Media | Akash storage class |
+| ----- | ------------------- |
+| HDD   | `beta1`             |
+| SSD   | `beta2`             |
+| NVMe  | `beta3`             |
+
+Rook creates exactly one OSD per selected physical disk, including NVMe. At least two disks are required cluster-wide.
+
+| Selected topology                | Replica layout      | Failure domain |
+| -------------------------------- | ------------------- | -------------- |
+| Three or more storage hosts      | 3 copies, minimum 2 | Host           |
+| Two storage hosts                | 2 copies, minimum 1 | Host           |
+| One host with at least two disks | 2 copies, minimum 1 | OSD            |
+
+A one-host layout can survive one disk failure but not loss of that host. Use at least three storage hosts for production host-level availability.
+
+The wizard shows every exact stable disk path and requires explicit confirmation before deployment. Rook consumes the selected disks after confirmation. On rerun, an existing Ceph cluster reuses its recorded exact layout; the installer stops instead of guessing replacement disks when that protected record is unavailable.
+
+After installation, the Rook role verifies the expected OSD count, per-node distribution, Ceph health, and StorageClass. When the provider is selected, the provider role also provisions and mounts a temporary claim before advertising persistent storage; that claim check works with Rook or another compatible storage class.
+
+## Generated files and secrets
+
+Normal installation creates these paths in the repository:
+
+- `.venv/` — the pinned Ansible environment for this project.
+- `.generated/inventory/` — generated inventory and encoded credentials.
+- `.cache/kubespray/` — Kubespray checkout and environment, created only when Kubespray is selected.
+
+All are ignored by Git. Files containing wallet, DNS, Tailscale, or rendered provider credentials are written with mode `0600`. Base64-encoded material is still secret; do not copy `.generated` into source control or share it.
+
+## Generate configuration without installing
+
+Use configuration-only mode to inspect the inventory before installing packages or changing hosts:
 
 ```bash
-./scripts/setup_provider.sh
+./scripts/setup_provider.sh --config-only
 ```
 
-The script will:
-1. Display a welcome banner
-2. Guide you through playbook selection
-3. Install all prerequisites automatically
-4. Collect your configuration information
-5. Set up SSH keys across all nodes
-6. Run the selected playbooks
+This mode still validates SSH and performs remote discovery. It does not create `.venv`, install the isolated Python runtime on hosts, download Kubespray, install `akt`, or deploy roles. Because wallet tooling is not installed, provide pre-encoded wallet material when prompted.
 
----
+The resulting inventory is not immediately runnable on a fresh clone. Follow the repository's [manual bootstrap instructions](https://github.com/akash-network/provider-playbooks#manual-execution) before invoking Ansible yourself.
 
-## Interactive Setup Process
+## Current component versions
 
-### Playbook Selection
+The repository keeps compatibility pins in [`versions.yml`](https://github.com/akash-network/provider-playbooks/blob/main/versions.yml). The installer loads this matrix rather than selecting unbounded `latest` releases.
 
-The script will ask you to select which components to install:
+| Component           | Pinned version                       |
+| ------------------- | ------------------------------------ |
+| Kubespray           | `v2.31.0`                            |
+| K3s                 | `v1.35.3+k3s1`                       |
+| Calico              | `v3.31.5`                            |
+| Helm                | `v4.2.4`                             |
+| NVIDIA GPU Operator | `v26.7.0`                            |
+| Rook-Ceph           | `1.19.10`                            |
+| Ceph                | `quay.io/ceph/ceph:v19.2.6-20260818` |
+| `akt`               | `0.1.1`                              |
 
-**Kubernetes Installation** (required for new clusters)
-- **Kubespray**: Production-grade, full-featured Kubernetes (recommended)
-- **K3s**: Lightweight, single binary, ideal for edge/IoT
+Treat `versions.yml` as the source of truth if this table and the repository ever differ.
 
-**Optional Components:**
-- **OS**: Basic OS configuration and optimizations
-- **GPU**: NVIDIA driver and container toolkit installation
-- **Provider**: Akash Provider service installation
-- **Tailscale**: VPN setup for secure remote access
-- **Rook-Ceph**: Storage operator installation and configuration
+## Verify the installation
 
-### Configuration Collection
+Some Helm releases intentionally return after Kubernetes accepts them, while their controllers and pods continue reconciling. In particular, the GPU Operator, Akash node, and provider are not treated as synchronous readiness gates.
 
-The script will interactively collect:
-- Provider domain and `location-region`
-- Organization details
-- Node IP addresses and SSH credentials
-- Wallet setup (create or import)
-- Storage configuration (if using Rook-Ceph)
-- Tailscale auth key (if using Tailscale)
+A new provider wallet has no funds. Fund its address before expecting the provider pod to become ready and register or bid on-chain.
 
-### Automated Execution
+Check progress with:
 
-Once configured, the script will:
-- Install Python 3.12, Ansible, and dependencies
-- Clone Kubespray (if using Kubespray)
-- Set up SSH keys on all nodes
-- Create Ansible inventory files
-- Run selected Ansible playbooks
-- Optionally reboot nodes after completion
+```bash
+sudo kubectl get nodes
+sudo kubectl get pods --all-namespaces
+sudo kubectl get pods --namespace akash-services
+sudo kubectl logs --namespace akash-services akash-provider-0 --follow
+```
 
----
+Verify the provider's on-chain record with the installer context selected explicitly:
 
-## What Happens During Installation
+```bash
+sudo --set-home akt --context provider query provider <provider-address>
+```
 
-### Prerequisite Installation
-The script automatically installs:
-- Python 3.12 with venv
-- Ansible and dependencies
-- `yq`, `jq`, `unzip`, and other tools
-- `provider-services` CLI
-- Kubespray repository (if using Kubespray)
+See [Provider Verification](/docs/providers/operations/provider-verification) for the complete checklist.
 
-### SSH Key Setup
-- Generates SSH key if none exists
-- Distributes key to all nodes
-- Supports password-based authentication for initial setup
-- Falls back to manual setup instructions if needed
+## Rerun a component
 
-### Wallet Setup
-Choose one of the following:
-- **Create new wallet**: Script generates a new wallet and exports the key
-- **Import key file**: Import existing `key.pem` file
-- **Import seed phrase**: Recover wallet from mnemonic
-- **Paste existing**: Provide AKT address and base64 encoded key
+The normal installer runs as root, so rerun Ansible as root from the repository root to retain access to its virtual environment, generated inventory, SSH key, and `akt` context:
 
-The script will:
-- Export and base64 encode your key
-- Save it to `host_vars/node1.yml`
-- Securely prompt for your key password
+```bash
+sudo --set-home env ANSIBLE_CONFIG="$PWD/ansible.cfg" \
+  .venv/bin/ansible-playbook \
+  --inventory .generated/inventory/hosts.ini \
+  playbooks.yml \
+  --tags provider
+```
 
-### Kubernetes Installation
-
-**If using Kubespray:**
-- Clones Kubespray v2.31.0
-- Creates Python virtual environment
-- Installs Kubespray requirements
-- Generates inventory files
-- Configures containerd with NVIDIA runtime
-- Deploys Kubernetes cluster
-- Installs local-path-provisioner (if not using Rook-Ceph)
-
-**If using K3s:**
-- Installs lightweight K3s distribution
-- Configures custom kubelet and data directories
-- Sets up Calico CNI
-- Includes local-path-provisioner by default
-
-### Provider Installation
-- Detects GPU hardware automatically
-- Creates provider configuration
-- Sets up pricing script
-- Deploys provider service
-- Configures provider attributes
-
-### Storage Setup (Rook-Ceph)
-If selected:
-- Creates OSD configuration
-- Deploys Rook operator
-- Configures Ceph cluster
-- Sets up storage classes (beta1/beta2/beta3)
-- Handles ZFS ephemeral storage if needed
-
----
-
-## Ephemeral Storage Configuration
-
-The script will ask if you use separate ephemeral storage:
-
-**Separate ephemeral storage:**
-- Specify mount location (e.g., `/mnt/ephemeral`)
-- Script configures kubelet and containerd paths
-- Useful for RAID or dedicated fast storage
-
-**Default ephemeral storage:**
-- Uses standard system paths
-- `/var/lib/kubelet` for kubelet
-- `/var/lib/containerd` for containerd
-- `/var/lib/rancher/k3s` for K3s
-
----
-
-## Post-Installation
-
-After the playbook completes:
-
-1. **Node Reboot (Optional)**
-   - Script offers to reboot all nodes
-   - Nodes reboot in reverse order
-   - Recommended for applying all system changes
-
-2. **Verify Installation**
-   ```bash
-   # Check Kubernetes cluster
-   kubectl get nodes
-   
-   # Check all pods are running
-   kubectl get pods -A
-   
-   # Check provider pods specifically
-   kubectl get pods -n akash-services
-   
-   # View provider logs
-   kubectl logs -n akash-services -l app=akash-provider -f
-   ```
-
-3. **Next Steps**
-   - Configure provider pricing
-   - Set up monitoring
-   - Test with a deployment
-   - Review provider attributes
-
-See [Operations](/docs/providers/operations) for ongoing management.
-
----
+Available tags include `preflight`, `tailscale`, `k3s`, `os`, `local-path`, `gpu`, `rook-ceph`, and `provider`.
 
 ## Troubleshooting
 
-### SSH Connection Issues
-- **Error**: "Permission denied (publickey)"
-  - **Solution**: The script will offer to use password authentication or provide manual setup instructions
+### SSH validation fails
 
-- **Error**: "Connection refused"
-  - **Solution**: Verify node IP address and SSH port are correct
+- Add the displayed public key to the exact user's `~/.ssh/authorized_keys` on every node.
+- Verify the entered IPv4 address and port are reachable.
+- For non-root users, confirm `sudo -n true` succeeds without a password prompt.
+- Password authentication is deliberately unsupported.
 
-### Kubernetes Installation Issues
-- **Kubespray fails**: 
-  - Check system requirements meet [Hardware Requirements](/docs/providers/getting-started/hardware-requirements)
-  - Verify network connectivity between nodes
-  - Review kubespray logs in the terminal output
+### No Ceph disks are eligible
 
-- **K3s fails**:
-  - Check systemd status: `systemctl status k3s`
-  - Review logs: `journalctl -u k3s -f`
+Review the exclusion reason shown for each disk. Ceph devices must be dedicated, empty whole disks with stable `/dev/disk/by-id` paths. The wizard will not clean an in-use or previously formatted device for you.
 
-### Provider Service Issues
-- **Wallet errors**:
-  - Deployment deposit is in **ACT** (tenant escrow); provider bid deposit is in **AKT**. Ensure sufficient ACT for escrow and AKT for bid deposits and gas.
-  - Check key password was entered correctly
-  - Ensure key is properly base64 encoded
+### A newly installed component is not ready yet
 
-- **Provider won't start**:
-  - Check provider logs: `kubectl logs -n akash-services -l app=akash-provider`
-  - Verify domain name is correctly configured
-  - Ensure ports 8443 and 8444 are accessible
+Helm acceptance does not mean every controller, image pull, blockchain sync, GPU driver build, or provider pod is complete. Inspect the relevant namespace with `kubectl get pods` and `kubectl describe pod`, then follow the failing pod's logs.
 
-### Storage Issues
-- **Rook-Ceph fails**:
-  - Verify storage devices are clean and available: `lsblk`
-  - Check device names match configuration
-  - Ensure at least one storage node is selected
-  - Review Ceph operator logs: `kubectl logs -n rook-ceph -l app=rook-ceph-operator`
-
-For more help, see [Provider Verification](/docs/providers/operations/provider-verification).
-
----
-
-## Advanced Configuration
-
-### Manual Execution
-
-If you need to run specific playbooks manually after initial setup:
-
-```bash
-# Activate virtual environment
-source ~/kubespray/venv/bin/activate
-
-# Run all playbooks
-ansible-playbook -i ~/kubespray/inventory/akash/inventory.ini playbooks.yml
-
-# Run specific playbooks using tags
-ansible-playbook -i ~/kubespray/inventory/akash/inventory.ini playbooks.yml -t os,provider,gpu
-
-# Run K3s specific playbooks
-ansible-playbook -i ~/kubespray/inventory/akash/inventory.ini playbooks.yml -t k3s
-
-# Run Rook-Ceph playbook
-ansible-playbook -i ~/kubespray/inventory/akash/inventory.ini playbooks.yml -t rook-ceph
-```
-
-### Configuration Files
-
-After setup, your configuration will be in:
-
-- **Inventory**: `~/kubespray/inventory/akash/inventory.ini`
-- **Host Variables**: `/root/provider-playbooks/host_vars/`
-- **Kubespray Config**: `~/kubespray/inventory/akash/group_vars/`
-- **Provider Config**: Generated during provider playbook execution
-
-### Customizing Playbooks
-
-You can customize the playbooks by editing:
-
-- `~/provider-playbooks/roles/*/defaults/main.yml` - Default variables
-- `/root/provider-playbooks/host_vars/node*.yml` - Per-node configuration
-- `~/kubespray/inventory/akash/group_vars/` - Kubernetes cluster settings
-
----
-
-## Next Steps
-
-**After setup:**
-- [Operations →](/docs/providers/operations) - Daily provider management
-- [Provider Verification →](/docs/providers/operations/provider-verification) - Verify your setup
-
-**Alternative methods:**
-- [Kubespray →](/docs/providers/setup-and-installation/kubespray) - Full control with manual setup
-- [Provider Console →](/docs/providers/setup-and-installation/provider-console) - Web-based setup
-
----
+For ongoing management, continue to [Provider Operations](/docs/providers/operations).
 
 ## Resources
 
-- **GitHub Repository:** [akash-network/provider-playbooks](https://github.com/akash-network/provider-playbooks)
-- **Report Issues:** [GitHub Issues](https://github.com/akash-network/provider-playbooks/issues)
-- **Discord:** [discord.akash.network](https://discord.akash.network) - #providers channel
-- **Documentation:** [docs.akash.network](https://docs.akash.network)
-
+- [Provider Playbooks repository](https://github.com/akash-network/provider-playbooks)
+- [Provider Playbooks issues](https://github.com/akash-network/provider-playbooks/issues)
+- [Manual Kubespray setup](/docs/providers/setup-and-installation/kubespray)
+- [Akash Discord](https://discord.akash.network) — `#providers`


### PR DESCRIPTION
## Summary

- rewrite the Provider Playbook guide around the new interactive installer and its Kubespray, K3s, and existing-cluster paths
- document SSH key onboarding, network and hardware discovery, location helpers, wallet handling, and the cluster → GPU → storage → provider installation order
- update GPU documentation for GPU Operator 26.7.0, CDI/NRI, Fabric Manager detection, Network Operator 26.7.0, and CUDA 13 validation
- update Rook-Ceph guidance for exact eligible disk discovery, one OSD per physical disk, cluster-wide replica recommendations, and destructive confirmation
- replace legacy `akash` and `provider-services` examples with `akt` 0.1.1 commands and the dedicated `provider` context
- align provider, gateway, operator, Helm, Rook-Ceph, Ceph, cert-manager, and infrastructure version references with the Provider Playbook compatibility matrix
- refresh monitoring, verification, lease management, attributes, IP leases, reclamation, and confidential-compute guidance

## Validation

- `npx prettier --check` passes for every changed file
- `git diff --check` passes
- `npm run build` passes and renders 655 pages
- `npm run astro -- check` retains the website repository's existing baseline issues (234 errors and 656 hints); none are reported in the changed Markdown or MDX files

## Related change

Documents the merged Provider Playbooks modernization work.
